### PR TITLE
Addressing an incompatibility between browsers when reporting errors.

### DIFF
--- a/debugger/adapter/sourceMaps/sourceMapTransformer.ts
+++ b/debugger/adapter/sourceMaps/sourceMapTransformer.ts
@@ -190,7 +190,7 @@ export class SourceMapTransformer implements IDebugTransformer {
                 // for it anyway and make sure to enable them
                 let scriptUrl = event.body.scriptUrl;
                 if (this._pendingBreakpointsByPath.has(scriptUrl)) {
-                    var pendingBreakpoint = this._pendingBreakpointsByPath.get(scriptUrl);
+                    let pendingBreakpoint = this._pendingBreakpointsByPath.get(scriptUrl);
                     this._pendingBreakpointsByPath.delete(scriptUrl);
                     this.setBreakpoints(pendingBreakpoint.args, pendingBreakpoint.requestSeq)
                         .then(pendingBreakpoint.resolve, pendingBreakpoint.reject);

--- a/debugger/webkit/webKitDebugAdapter.ts
+++ b/debugger/webkit/webKitDebugAdapter.ts
@@ -465,11 +465,11 @@ export class WebKitDebugAdapter implements IDebugAdapter {
                     // In these cases, return a dummy stack frame
                     return {
                         id: i,
-                        name: "Unknown",
+                        name: 'Unknown',
                         source: {name: 'eval:Unknown'},
                         line,
                         column
-                    }
+                    };
                 }
             });
 
@@ -560,7 +560,13 @@ export class WebKitDebugAdapter implements IDebugAdapter {
 
         return evalPromise.then(evalResponse => {
             if (evalResponse.result.wasThrown) {
-                const errorMessage = evalResponse.result.exceptionDetails ? evalResponse.result.exceptionDetails.text : 'Error';
+                const evalResult = evalResponse.result;
+                let errorMessage: string = 'Error';
+                if (evalResult.exceptionDetails) {
+                    errorMessage = evalResult.exceptionDetails.text;
+                } else if (evalResult.result && evalResult.result.description) {
+                    errorMessage = evalResult.result.description;
+                }
                 return utils.errP(errorMessage);
             }
 


### PR DESCRIPTION
Also addressing a couple of tslint issues.

The main problem here was that chrome reports errors in one way, with an `exceptionDetails.text` property, while iOS and android have a `result.description` property instead.