### PR TITLE
Fixing incorrect case in file paths

### DIFF
--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 
 import {TsdHelper} from './utils/tsdHelper';
 import {CordovaProjectHelper} from './utils/cordovaProjectHelper';
-import {CordovaCommandHelper} from './utils/CordovaCommandHelper';
+import {CordovaCommandHelper} from './utils/cordovaCommandHelper';
 import {Telemetry} from './utils/telemetry';
 import {TelemetryHelper} from './utils/telemetryHelper';
 

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -13,7 +13,7 @@ import {CordovaIosDeviceLauncher} from './cordovaIosDeviceLauncher';
 
 import {cordovaRunCommand, execCommand} from './extension';
 
-import {WebKitDebugAdapter} from '../../debugger/webkit/WebKitDebugAdapter';
+import {WebKitDebugAdapter} from '../../debugger/webkit/webKitDebugAdapter';
 
 import {CordovaProjectHelper} from '../utils/cordovaProjectHelper';
 

--- a/src/debugger/cordovaIosDeviceLauncher.ts
+++ b/src/debugger/cordovaIosDeviceLauncher.ts
@@ -3,12 +3,12 @@
 
 'use strict';
 
-import child_process = require ('child_process');
-import fs = require ('fs');
-import net = require ('net');
-import path = require('path');
-import pl = require ('plist-with-patches');
-import Q = require ('q');
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+import * as net from 'net';
+import * as path from 'path';
+import * as pl from 'plist-with-patches';
+import * as Q from 'q';
 
 let promiseExec = Q.denodeify(child_process.exec);
 


### PR DESCRIPTION
While I'm here, also updating some imports to the new syntax.

I believe that this should fix issue #26 as these were the only two paths with incorrect casing that I could see.