### PR TITLE
Fixing over-encoding of paths for iOS device debugging

### DIFF
--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -231,7 +231,9 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
         this.outputLogger('Configuring debugging proxy');
         return CordovaIosDeviceLauncher.startWebkitDebugProxy(attachArgs.port, attachArgs.webkitRangeMin, attachArgs.webkitRangeMax).then(() => {
             if (attachArgs.target.toLowerCase() === 'device') {
-                return CordovaIosDeviceLauncher.getBundleIdentifier(attachArgs.cwd).then(CordovaIosDeviceLauncher.getPathOnDevice);
+                return CordovaIosDeviceLauncher.getBundleIdentifier(attachArgs.cwd)
+                    .then(CordovaIosDeviceLauncher.getPathOnDevice)
+                    .then(path.basename);
             } else {
                 return Q.nfcall(fs.readdir, path.join(attachArgs.cwd, 'platforms', 'ios', 'build', 'emulator')).then((entries: string[]) => {
                    let filtered = entries.filter((entry) => /\.app$/.test(entry));


### PR DESCRIPTION
When attempting to determine which webview to attach to we URL encode the package name to deal with spaces and other special characters. However prior to this fix we pass the whole on-device path for device debugging, and we would URL encode the path separators. Now we only match on, and encode, the app folder itself.

Fixes #30 