### PR TITLE
New command: Cordova Prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
             {
                 "command": "cordova.run",
                 "title": "Cordova: Run"
+            },
+            {
+                "command": "cordova.prepare",
+                "title": "Cordova: Prepare"
             }
         ],
         "keybindings": [

--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -39,6 +39,8 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(watcher);
 
     // Register Cordova commands
+    context.subscriptions.push(vscode.commands.registerCommand('cordova.prepare',
+        () => CordovaCommandHelper.executeCordovaCommand(cordovaProjectRoot, "prepare")));
     context.subscriptions.push(vscode.commands.registerCommand('cordova.build',
         () => CordovaCommandHelper.executeCordovaCommand(cordovaProjectRoot, "build")));
     context.subscriptions.push(vscode.commands.registerCommand('cordova.run',

--- a/test/cordova.test.ts
+++ b/test/cordova.test.ts
@@ -63,7 +63,7 @@ suite("VSCode Cordova extension - intellisense and command palette tests", () =>
             let cordovaCmdsAvailable = results.filter((commandName: string) => {
                 return commandName.indexOf("cordova.") > -1
             });
-            assert.deepEqual(cordovaCmdsAvailable, ["cordova.build", "cordova.run"])
+            assert.deepEqual(cordovaCmdsAvailable, ["cordova.build", "cordova.run", "cordova.prepare"])
         });
     });
 


### PR DESCRIPTION
The goal of this feature is to add a new command in VSCode to prepare the cordova platform.