### PR TITLE
Adding telemetry for cordova-simulate

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
                         "platform": "android",
                         "target": "chrome",
                         "port": 8000,
+                        "livereload": true,
                         "cwd": "${workspaceRoot}"
                     },
                     {
@@ -209,6 +210,7 @@
                         "platform": "ios",
                         "target": "chrome",
                         "port": 8000,
+                        "livereload": true,
                         "cwd": "${workspaceRoot}"
                     }
                 ],
@@ -284,6 +286,14 @@
                             "devServerAddress": {
                                 "type": "string",
                                 "description": "The IP address that Ionic should use for the live reload server"
+                            },
+                            "livereload": {
+                                "type": "boolean",
+                                "description": "When simulating in the browser, determines whether live reload is enabled"
+                            },
+                            "forceprepare": {
+                                "type": "boolean",
+                                "description": "When simulating in the browser, determines whether a file change triggers a cordova prepare before live reloading"
                             }
                         }
                     },

--- a/src/common/extensionMessaging.ts
+++ b/src/common/extensionMessaging.ts
@@ -49,14 +49,14 @@ export class ExtensionMessageSender {
         });
 
         socket.on("error", function(data: any) {
-            deferred.reject(new Error("An error ocurred while handling message: " + ExtensionMessage[message]));
+            deferred.reject(new Error("An error occurred while handling message: " + ExtensionMessage[message]));
         });
 
         socket.on("end", function () {
             try {
                 if (body.startsWith(ErrorMarker)) {
                     let errorString = body.replace(ErrorMarker, "");
-                    let error = new Error(errorString ? errorString : "An error ocurred while handling message: " + ExtensionMessage[message]);
+                    let error = new Error(errorString ? errorString : "An error occurred while handling message: " + ExtensionMessage[message]);
                     deferred.reject(error);
                 } else {
                     let responseBody: any = body ? JSON.parse(body) : null;

--- a/src/debugger/cordovaAdapterInferfaces.d.ts
+++ b/src/debugger/cordovaAdapterInferfaces.d.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 
- interface ICordovaLaunchRequestArgs extends DebugProtocol.LaunchRequestArguments, ICordovaAttachRequestArgs {
+interface ICordovaLaunchRequestArgs extends DebugProtocol.LaunchRequestArguments, ICordovaAttachRequestArgs {
     iosDebugProxyPort?: number;
     appStepLaunchTimeout?: number;
 
@@ -14,6 +14,10 @@
     // Chrome debug properties
     url?: string;
     userDataDir?: string;
+
+    // Cordova-simulate properties
+    livereload?: boolean;
+    forceprepare?: boolean;
 }
 
 interface ICordovaAttachRequestArgs extends DebugProtocol.AttachRequestArguments, IAttachRequestArgs {

--- a/src/extension/simulate.ts
+++ b/src/extension/simulate.ts
@@ -6,6 +6,7 @@ import * as Q from "q";
 import * as cordovaServer from "cordova-serve";
 import * as path from "path";
 import * as simulate from "cordova-simulate";
+import {CordovaSimulateTelemetry} from "../utils/cordovaSimulateTelemetry";
 import * as vscode from "vscode";
 
 /**
@@ -37,6 +38,9 @@ export class PluginSimulator implements vscode.Disposable {
         return this.isServerRunning()
             .then((isRunning: boolean) => {
                 if (!isRunning) {
+                    let simulateTelemetryWrapper = new CordovaSimulateTelemetry();
+                    simulateOptions.telemetry = simulateTelemetryWrapper;
+
                     return simulate.launchServer(simulateOptions)
                         .then(simulateInfo => {
                             this.simulateInfo = simulateInfo;

--- a/src/utils/cordovaSimulateTelemetry.ts
+++ b/src/utils/cordovaSimulateTelemetry.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import {Telemetry} from './telemetry';
+import {TelemetryGenerator, TelemetryHelper} from './telemetryHelper';
+
+/**
+ * This class is a telemetry wrapper compatible with cordova-simulate's telemetry. Cordova-simulate expects an object with a sendTelemetry() function, and calls it every time there is a
+ * telemetry event. This wrapper creates a telemetry event compatible with vscode-cordova's telemetry, based on cordova-simulate's event, and sends it using the Telemetry module.
+ */
+export class CordovaSimulateTelemetry {
+    public sendTelemetry(eventName: string, props: Telemetry.ITelemetryProperties, piiProps: Telemetry.ITelemetryProperties): void {
+        let fullEventName = 'cordova-simulate-' + eventName;
+        let generator = new TelemetryGenerator(fullEventName);
+        let telemetryEvent = new Telemetry.TelemetryEvent(fullEventName);
+
+        Object.keys(props).forEach((prop) => {
+            generator.add(prop, props[prop], false);
+        });
+
+        Object.keys(piiProps).forEach((prop) => {
+            generator.add(prop, piiProps[prop], true);
+        });
+
+        TelemetryHelper.addTelemetryEventProperties(telemetryEvent, generator.getTelemetryProperties());
+        Telemetry.send(telemetryEvent);
+    }
+}

--- a/src/utils/telemetryHelper.ts
+++ b/src/utils/telemetryHelper.ts
@@ -53,9 +53,9 @@ export abstract class TelemetryGeneratorBase {
         //     * Object is a value, we add the element as baseName
         try {
             if (Array.isArray(value)) {
-                this.addArray(baseName, <any[]> value, piiEvaluator);
+                this.addArray(baseName, <any[]>value, piiEvaluator);
             } else if (!!value && (typeof value === 'object' || typeof value === 'function')) {
-                this.addHash(baseName, <IDictionary<any>> value, piiEvaluator);
+                this.addHash(baseName, <IDictionary<any>>value, piiEvaluator);
             } else {
                 this.addString(baseName, String(value), piiEvaluator);
             }
@@ -70,7 +70,7 @@ export abstract class TelemetryGeneratorBase {
 
     public addError(error: Error): TelemetryGeneratorBase {
         this.add('error.message' + ++this.errorIndex, error.message, /*isPii*/ true);
-        var errorWithErrorCode: IHasErrorCode = <IHasErrorCode> <Object> error;
+        var errorWithErrorCode: IHasErrorCode = <IHasErrorCode><Object>error;
         if (errorWithErrorCode.errorCode) {
             this.add('error.code' + this.errorIndex, errorWithErrorCode.errorCode, /*isPii*/ false);
         }
@@ -104,6 +104,10 @@ export abstract class TelemetryGeneratorBase {
         }
 
         this.step(null); // Send the last step
+    }
+
+    public getTelemetryProperties(): ICommandTelemetryProperties {
+        return this.telemetryProperties;
     }
 
     private sendCurrentStep(): void {
@@ -173,9 +177,9 @@ export class TelemetryHelper {
         let phonegap = promiseExists(path.join(projectRoot, 'www', 'res', '.pgbomit'));
         let cordova = promiseExists(path.join(projectRoot, 'config.xml'));
         return Q.all([meteor, mobilefirst, phonegap, cordova])
-        .spread((isMeteor: boolean, isMobilefirst: boolean, isPhonegap: boolean, isCordova: boolean) => {
-            return {ionic: isIonic, ionic2: isIonic2, meteor: isMeteor, mobilefirst: isMobilefirst, phonegap: isPhonegap, cordova: isCordova};
-        });
+            .spread((isMeteor: boolean, isMobilefirst: boolean, isPhonegap: boolean, isCordova: boolean) => {
+                return { ionic: isIonic, ionic2: isIonic2, meteor: isMeteor, mobilefirst: isMobilefirst, phonegap: isPhonegap, cordova: isCordova };
+            });
     }
 
     public static telemetryProperty(propertyValue: any, pii?: boolean): ITelemetryPropertyInfo {

--- a/typings/cordova-simulate/cordova-simulate.d.ts
+++ b/typings/cordova-simulate/cordova-simulate.d.ts
@@ -2,6 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 declare module "cordova-simulate" {
+    interface PropertyDictionary {
+        [propName: string]: any;
+    }
+
     export interface SimulateOptions {
         platform?: string;
         target?: string;
@@ -9,7 +13,12 @@ declare module "cordova-simulate" {
         dir?: string;
         simhostui?: string;
         livereload?: boolean;
-        forceprepare?:boolean;
+        forceprepare?: boolean;
+        telemetry?: TelemetryModule;
+    }
+
+    export interface TelemetryModule {
+        sendTelemetry: (eventName: string, props: PropertyDictionary, piiProps: PropertyDictionary) => void;
     }
 
     export interface SimulateInfo {


### PR DESCRIPTION
- Added more telemetry properties to the launch event for cordova-simulate
- Created a telemetry wrapper compatible with cordova-simulate's telemetry events in order to send cordova-simulate telemetry