### PR TITLE
Version bump and a couple of tslint errors fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cordova-tools",
     "displayName": "Cordova Tools",
     "description": "Code-hinting, debugging and integrated commands for Apache Cordova (PhoneGap)",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "private": true,
     "publisher": "vsmobile",
     "icon": "images/icon.png",

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -411,18 +411,18 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
     }
 
     private launchSimulate(launchArgs: ICordovaLaunchRequestArgs, generator: TelemetryGenerator): Q.Promise<void> {
-        let simulateTelemetryPropts = {
+        let simulateTelemetryPropts: any = {
             platform: launchArgs.platform,
             target: launchArgs.target,
             port: launchArgs.port
         };
 
         if (launchArgs.hasOwnProperty('livereload')) {
-            simulateTelemetryPropts['livereload'] = launchArgs.livereload;
+            simulateTelemetryPropts.livereload = launchArgs.livereload;
         }
 
         if (launchArgs.hasOwnProperty('forceprepare')) {
-            simulateTelemetryPropts['forceprepare'] = launchArgs.forceprepare;
+            simulateTelemetryPropts.forceprepare = launchArgs.forceprepare;
         }
 
         generator.add('simulateOptions', simulateTelemetryPropts, false);

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -16,7 +16,7 @@ import {cordovaRunCommand, cordovaStartCommand, execCommand, killChildProcess} f
 import {CordovaPathTransformer} from './cordovaPathTransformer';
 import {WebKitDebugAdapter} from '../../debugger/webkit/webKitDebugAdapter';
 import {CordovaProjectHelper} from '../utils/cordovaProjectHelper';
-import {IProjectType, TelemetryHelper, TelemetryGenerator} from '../utils/telemetryHelper';
+import {IProjectType, ISimulateTelemetryProperties, TelemetryHelper, TelemetryGenerator} from '../utils/telemetryHelper';
 import {settingsHome} from '../utils/settingsHelper';
 
 export class CordovaDebugAdapter extends WebKitDebugAdapter {
@@ -411,7 +411,7 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
     }
 
     private launchSimulate(launchArgs: ICordovaLaunchRequestArgs, generator: TelemetryGenerator): Q.Promise<void> {
-        let simulateTelemetryPropts: any = {
+        let simulateTelemetryPropts: ISimulateTelemetryProperties = {
             platform: launchArgs.platform,
             target: launchArgs.target,
             port: launchArgs.port

--- a/src/utils/telemetryHelper.ts
+++ b/src/utils/telemetryHelper.ts
@@ -158,6 +158,14 @@ export interface IProjectType {
     cordova: boolean;
 }
 
+export interface ISimulateTelemetryProperties {
+    platform?: string;
+    target: string;
+    port: number;
+    livereload?: boolean;
+    forceprepare?: boolean
+}
+
 export class TelemetryHelper {
     public static createTelemetryEvent(eventName: string): Telemetry.TelemetryEvent {
         return new Telemetry.TelemetryEvent(eventName);


### PR DESCRIPTION
Non related, but all the code from `browser-workflow` is in `master` now. We will have all our PRs against `master` going forward.