### PR TITLE
Telemetry points for debugging failures and vscode window

### DIFF
--- a/src/common/extensionMessaging.ts
+++ b/src/common/extensionMessaging.ts
@@ -11,6 +11,7 @@ export let ErrorMarker = "vscode-cordova-error-marker";
  * Add new messages to this enum.
  */
 export enum ExtensionMessage {
+    GET_VISIBLE_EDITORS_COUNT,
     LAUNCH_SIM_HOST,
     SEND_TELEMETRY,
     SIMULATE,

--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -78,6 +78,8 @@ export function activate(context: vscode.ExtensionContext): void {
                 .then((projectType) => {
                     generator.add("simulateOptions", options, false);
                     generator.add("projectType", projectType, false);
+                    // visibleTextEditors is null proof (returns empty array if no editors visible)
+                    generator.add("visibleTextEditors", vscode.window.visibleTextEditors.length, false);
                 });
         }).then(() => {
             simulator.simulate(options);

--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -79,7 +79,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     generator.add("simulateOptions", options, false);
                     generator.add("projectType", projectType, false);
                     // visibleTextEditors is null proof (returns empty array if no editors visible)
-                    generator.add("visibleTextEditors", vscode.window.visibleTextEditors.length, false);
+                    generator.add("visibleTextEditorsCount", vscode.window.visibleTextEditors.length, false);
                 });
         }).then(() => {
             simulator.simulate(options);

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -437,6 +437,10 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
 
         return Q(void 0)
             .then(() => {
+                return messageSender.sendMessage(messaging.ExtensionMessage.GET_VISIBLE_EDITORS_COUNT);
+            }).then((editorCount) => {
+                generator.add('visibleTextEditors', editorCount, false);
+            }).then(() => {
                 let simulateOptions = this.convertLaunchArgsToSimulateArgs(launchArgs);
                 return messageSender.sendMessage(messaging.ExtensionMessage.START_SIMULATE_SERVER, [simulateOptions]);
             }).then((simInfo: simulate.SimulateInfo) => {
@@ -451,6 +455,10 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
                 this.outputLogger('Attaching to app');
 
                 return super.launch(launchArgs);
+            }).catch((e) => {
+                this.outputLogger('An error occurred while attaching to the debugger. ' + e.message || e.error || e.data || e);
+                generator.addError(e);
+                throw e;
             }).then(() => void 0);
     }
 

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -32,7 +32,7 @@ export class ExtensionServer implements vscode.Disposable {
         this.messageHandlerDictionary[ExtensionMessage.LAUNCH_SIM_HOST] = this.launchSimHost;
         this.messageHandlerDictionary[ExtensionMessage.SIMULATE] = this.simulate;
         this.messageHandlerDictionary[ExtensionMessage.START_SIMULATE_SERVER] = this.launchSimulateServer;
-        this.messageHandlerDictionary[ExtensionMessage.GET_VISIBLE_EDITORS_COUNT] = this.getVisibleEditorCount;
+        this.messageHandlerDictionary[ExtensionMessage.GET_VISIBLE_EDITORS_COUNT] = this.getVisibleEditorsCount;
     }
 
     /**
@@ -117,7 +117,7 @@ export class ExtensionServer implements vscode.Disposable {
     /**
      * Returns the number of currently visible editors.
      */
-    private getVisibleEditorCount(): Q.Promise<number> {
+    private getVisibleEditorsCount(): Q.Promise<number> {
         // visibleTextEditors is null proof (returns empty array if no editors visible)
         return Q.resolve(vscode.window.visibleTextEditors.length);
     }

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -32,6 +32,7 @@ export class ExtensionServer implements vscode.Disposable {
         this.messageHandlerDictionary[ExtensionMessage.LAUNCH_SIM_HOST] = this.launchSimHost;
         this.messageHandlerDictionary[ExtensionMessage.SIMULATE] = this.simulate;
         this.messageHandlerDictionary[ExtensionMessage.START_SIMULATE_SERVER] = this.launchSimulateServer;
+        this.messageHandlerDictionary[ExtensionMessage.GET_VISIBLE_EDITORS_COUNT] = this.getVisibleEditorCount;
     }
 
     /**
@@ -111,6 +112,14 @@ export class ExtensionServer implements vscode.Disposable {
      */
     private launchSimHost(): Q.Promise<void> {
         return this.pluginSimulator.launchSimHost();
+    }
+
+    /**
+     * Returns the number of currently visible editors.
+     */
+    private getVisibleEditorCount(): Q.Promise<number> {
+        // visibleTextEditors is null proof (returns empty array if no editors visible)
+        return Q.resolve(vscode.window.visibleTextEditors.length);
     }
 
     /**


### PR DESCRIPTION
I added telemetry for debugging errors and editor count when opening the simulate window.