### PR TITLE
Remove touch mode when resizing viewport

### DIFF
--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -465,14 +465,12 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
     }
 
     private changeSimulateViewport(data: simulate.ResizeViewportData): Q.Promise<void> {
-        let jsPromise = this._webKitConnection.emulation_setTouchEmulationEnabled(true, 'mobile').then(() => {
-            return this._webKitConnection.emulation_setDeviceMetricsOverride({
-                width: data.width,
-                height: data.height,
-                deviceScaleFactor: 0,
-                mobile: true,
-                fitWindow: true
-            });
+        let jsPromise = this._webKitConnection.emulation_setDeviceMetricsOverride({
+            width: data.width,
+            height: data.height,
+            deviceScaleFactor: 0,
+            mobile: true,
+            fitWindow: true
         }).then(() => void 0);
 
         return Q(jsPromise);
@@ -498,10 +496,8 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
                 }).done();
             });
             this.simulateDebugHost.on('reset-viewport', () => {
-                this.resetSimulateViewport().then(() => {
-                    this._webKitConnection.emulation_setTouchEmulationEnabled(false).catch((err) => {
-                        this.outputLogger(viewportResizeFailMessage, true);
-                    });
+                this.resetSimulateViewport().catch((err) => {
+                    this.outputLogger(viewportResizeFailMessage, true);
                 }).done();
             });
             this.simulateDebugHost.emit('register-debug-host', { handlers: ['reset-viewport', 'resize-viewport'] });
@@ -745,7 +741,7 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
 
     private promiseGet(url: string, reqErrMessage: string): Q.Promise<string> {
         let deferred = Q.defer<string>();
-        let req = http.get(url, function (res) {
+        let req = http.get(url, function(res) {
             let responseString = '';
             res.on('data', (data: Buffer) => {
                 responseString += data.toString();


### PR DESCRIPTION
Setting touch-mode emulation to true prevented clicking the "Resume" button in Chrome when the app was paused at a breakpoint. With this, we no longer set the simulation to touch mode when in a mobile viewport.