### PR TITLE
Restart the server with every simulate call

### DIFF
--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -72,8 +72,8 @@ export function activate(context: vscode.ExtensionContext): void {
     context.subscriptions.push(extensionServer);
 
     /* Launches a simulate command and records telemetry for it */
-    let launchSimulateCommand = function (options: SimulateOptions): void {
-        TelemetryHelper.generate("simulateCommand", (generator) => {
+    let launchSimulateCommand = function (options: SimulateOptions): Q.Promise<void> {
+        return TelemetryHelper.generate("simulateCommand", (generator) => {
             return TelemetryHelper.determineProjectTypes(cordovaProjectRoot)
                 .then((projectType) => {
                     generator.add("simulateOptions", options, false);
@@ -82,7 +82,7 @@ export function activate(context: vscode.ExtensionContext): void {
                     generator.add("visibleTextEditorsCount", vscode.window.visibleTextEditors.length, false);
                 });
         }).then(() => {
-            simulator.simulate(options);
+            return simulator.simulate(options);
         });
     };
 

--- a/src/extension/simulate.ts
+++ b/src/extension/simulate.ts
@@ -53,7 +53,9 @@ export class PluginSimulator implements vscode.Disposable {
             .then((isRunning: boolean) => {
                 if (isRunning) {
                     /* close the server old instance */
-                    return simulate.closeServer();
+                    return Q({})
+                    .then(()=> simulate.stopSimulate())
+                    .then(()=> simulate.closeServer());
                 }
             }).then(() => {
                 let simulateTelemetryWrapper = new CordovaSimulateTelemetry();

--- a/src/extension/simulate.ts
+++ b/src/extension/simulate.ts
@@ -54,8 +54,7 @@ export class PluginSimulator implements vscode.Disposable {
                 if (isRunning) {
                     /* close the server old instance */
                     return Q({})
-                    .then(()=> simulate.stopSimulate())
-                    .then(()=> simulate.closeServer());
+                    .then(()=> simulate.stopSimulate());
                 }
             }).then(() => {
                 let simulateTelemetryWrapper = new CordovaSimulateTelemetry();

--- a/src/extension/simulate.ts
+++ b/src/extension/simulate.ts
@@ -51,17 +51,19 @@ export class PluginSimulator implements vscode.Disposable {
 
         return this.isServerRunning()
             .then((isRunning: boolean) => {
-                if (!isRunning) {
-                    let simulateTelemetryWrapper = new CordovaSimulateTelemetry();
-                    simulateOptions.telemetry = simulateTelemetryWrapper;
-
-                    return simulate.launchServer(simulateOptions)
-                        .then(simulateInfo => {
-                            this.simulateInfo = simulateInfo;
-                        });
+                if (isRunning) {
+                    /* close the server old instance */
+                    return simulate.closeServer();
                 }
             }).then(() => {
-                return this.simulateInfo;
+                let simulateTelemetryWrapper = new CordovaSimulateTelemetry();
+                simulateOptions.telemetry = simulateTelemetryWrapper;
+
+                return simulate.launchServer(simulateOptions)
+                    .then(simulateInfo => {
+                        this.simulateInfo = simulateInfo;
+                        return this.simulateInfo;
+                    });
             });
     }
 

--- a/typings/cordova-simulate/cordova-simulate.d.ts
+++ b/typings/cordova-simulate/cordova-simulate.d.ts
@@ -36,4 +36,5 @@ declare module "cordova-simulate" {
     export function launchBrowser(target: string, url: string): Q.Promise<void>;
     export function launchServer(opts?: SimulateOptions): Q.Promise<SimulateInfo>;
     export function closeServer(): Q.Promise<void>;
+    export function stopSimulate(): Q.Promise<void>;
 }


### PR DESCRIPTION
During bashing I found an issue where the incorrect platform was being served due to reusing the simulate server. Restarting the server with every simulate call will ensure the right platform is being simulated. This PR depends on https://github.com/Microsoft/cordova-simulate/pull/52 being merged.