### PR TITLE
fix: typo on contacts typings

### DIFF
--- a/pluginTypings.json
+++ b/pluginTypings.json
@@ -9,7 +9,7 @@
         "typingFile": "cordova/plugins/Camera.d.ts"
     },
     "cordova-plugin-contacts": {
-        "typingFile": "cordova/plugins/Contact.d.ts"
+        "typingFile": "cordova/plugins/Contacts.d.ts"
     },
     "cordova-plugin-device": {
         "typingFile": "cordova/plugins/Device.d.ts"


### PR DESCRIPTION
Adding the contacts plugin adds an empty Contact.d.ts file. Looks like a typo (missing plural) in the mapping file.

This could close https://github.com/Microsoft/vscode-cordova/issues/141 