### PR TITLE
Adding the ability to disable XHR proxying

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,6 +309,11 @@
                                 "type": "string",
                                 "description": "The directory where temporary browser simulation files are hosted.",
                                 "default": "${workspaceRoot}/.vscode/simulation"
+                            },
+                            "corsproxy": {
+                                "type": "boolean",
+                                "description": "When simulating in the browser, determines whether XHR requests are proxied to appear as though they originate from the same domain as the target.",
+                                "default": true
                             }
                         }
                     },

--- a/src/debugger/cordovaAdapterInferfaces.d.ts
+++ b/src/debugger/cordovaAdapterInferfaces.d.ts
@@ -21,6 +21,7 @@ interface ICordovaLaunchRequestArgs extends DebugProtocol.LaunchRequestArguments
     livereload?: boolean;
     forceprepare?: boolean;
     simulateTempDir?: string;
+    corsproxy?: boolean;
 }
 
 interface ICordovaAttachRequestArgs extends DebugProtocol.AttachRequestArguments, IAttachRequestArgs {

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -533,6 +533,7 @@ export class CordovaDebugAdapter extends WebKitDebugAdapter {
         result.livereload = launchArgs.livereload;
         result.forceprepare = launchArgs.forceprepare;
         result.simulationpath = launchArgs.simulateTempDir;
+        result.corsproxy = launchArgs.corsproxy;
 
         return result;
     }

--- a/typings/cordova-simulate/cordova-simulate.d.ts
+++ b/typings/cordova-simulate/cordova-simulate.d.ts
@@ -16,6 +16,7 @@ declare module "cordova-simulate" {
         forceprepare?: boolean;
         telemetry?: TelemetryModule;
         simulationpath?: string;
+        corsproxy?: boolean;
     }
 
     export interface TelemetryModule {


### PR DESCRIPTION
As requested in #168, this exposes the ability to disable XHR proxying. Note that disabling this option will mean that XHR requests often fail for CORS or CSP reasons unless you put in your own workarounds.