### PR TITLE
Removing ion_list from ion_refresh snippet

### DIFF
--- a/snippets/ionicHtml.json
+++ b/snippets/ionicHtml.json
@@ -118,10 +118,7 @@
             "<ion-refresher",
             "\tpulling-text=\"${1:Pull to refresh...}\"",
             "\ton-refresh=\"${doRefresh()}\">",
-            "</ion-refresher>",
-            "<ion-list>",
-            "\t<ion-item ng-repeat=\"${2:item in items}\"></ion-item>",
-            "</ion-list>"
+            "</ion-refresher>"
         ],
         "description": "A snippet for an ion-refresher element"
     },


### PR DESCRIPTION
The ion_refresh example used a list, but a list is not inherently required in order to use ion_refresh.

Fixes #102 