### PR TITLE
Adding a note about Ionic to improve discoverability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cordova-tools",
     "displayName": "Cordova Tools",
-    "description": "Code-hinting, debugging and integrated commands for Apache Cordova (PhoneGap)",
+    "description": "Code-hinting, debugging and integrated commands for Apache Cordova (PhoneGap). With added support for the Ionic framework.",
     "version": "1.2.2",
     "private": true,
     "publisher": "vsmobile",


### PR DESCRIPTION
After talking with the PM team, we're going to add a note about Ionic so that our extension appears when VS Code users search for "ionic."