### PR TITLE
Allow VSCode to provide typings when possible

### DIFF
--- a/pluginTypings.json
+++ b/pluginTypings.json
@@ -57,10 +57,12 @@
         "typingFile": "cordova/plugins/WebSQL.d.ts"
     },
     "cordova-plugin-x-toast": {
-        "typingFile": "cordova/plugins/Toast.d.ts"
+        "typingFile": "cordova/plugins/Toast.d.ts",
+        "forceInstallTypings": true
     },
     "ionic-plugin-keyboard": {
-        "typingFile": "cordova-ionic/plugins/keyboard.d.ts"
+        "typingFile": "cordova-ionic/plugins/keyboard.d.ts",
+        "forceInstallTypings": true
     },
     "phonegap-plugin-barcodescanner": {
         "typingFile": "cordova/plugins/BarcodeScanner.d.ts"

--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -113,10 +113,10 @@ export function activate(context: vscode.ExtensionContext): void {
             path.join("cordova-ionic", "plugins", "keyboard.d.ts")
         ];
         if (CordovaProjectHelper.isIonic1Project(cordovaProjectRoot)) {
-            ionicTypings.push[
+            ionicTypings = ionicTypings.concat([
                 path.join("angularjs", "angular.d.ts"),
                 path.join("ionic", "ionic.d.ts")
-            ];
+            ]);
         }
         TsdHelper.installTypings(CordovaProjectHelper.getOrCreateTypingsTargetPath(cordovaProjectRoot), ionicTypings, cordovaProjectRoot);
     }

--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -190,22 +190,16 @@ function addPluginTypeDefinitions(projectRoot: string, installedPlugins: string[
         return pluginTypings[pluginName].typingFile;
     });
 
-    TsdHelper.installTypings(CordovaProjectHelper.getOrCreateTypingsTargetPath(projectRoot), typingsToAdd, CordovaProjectHelper.getCordovaProjectRoot(vscode.workspace.rootPath));
+    TsdHelper.installTypings(CordovaProjectHelper.getOrCreateTypingsTargetPath(projectRoot),
+        typingsToAdd, CordovaProjectHelper.getCordovaProjectRoot(vscode.workspace.rootPath));
 }
 
 function removePluginTypeDefinitions(projectRoot: string, currentTypeDefs: string[], newTypeDefs: string[]): void {
     // Find the type definition files that need to be removed
-    currentTypeDefs.forEach((typeDef: string) => {
-        if (newTypeDefs.indexOf(typeDef) < 0) {
-            var fileToDelete = path.resolve(CordovaProjectHelper.getOrCreateTypingsTargetPath(projectRoot), typeDef);
-            fs.unlink(fileToDelete, (err: Error) => {
-                if (err) {
-                    // Debug-only message
-                    console.log("Failed to delete file " + fileToDelete);
-                }
-            });
-        }
-    });
+    let typeDefsToRemove = currentTypeDefs
+        .filter((typeDef: string) => newTypeDefs.indexOf(typeDef) < 0)
+
+    TsdHelper.removeTypings(CordovaProjectHelper.getOrCreateTypingsTargetPath(projectRoot), typeDefsToRemove, projectRoot);
 }
 
 function getRelativeTypeDefinitionFilePath(projectRoot: string, parentPath: string, typeDefinitionFile: string) {

--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -213,6 +213,12 @@ function getRelativeTypeDefinitionFilePath(projectRoot: string, parentPath: stri
 }
 
 function updatePluginTypeDefinitions(cordovaProjectRoot: string): void {
+    // We don't need to install typings for Ionic2 since it has own TS
+    // wrapper around core plugins
+    if (CordovaProjectHelper.isIonic2Project(cordovaProjectRoot)) {
+        return;
+    }
+
     let installedPlugins: string[] = CordovaProjectHelper.getInstalledPlugins(cordovaProjectRoot);
 
     const nodeModulesDir = path.resolve(cordovaProjectRoot, 'node_modules');

--- a/src/utils/cordovaProjectHelper.ts
+++ b/src/utils/cordovaProjectHelper.ts
@@ -219,4 +219,12 @@ export class CordovaProjectHelper {
         }
         return false;
     }
+
+    /**
+     * Helper function to determine whether the project has a tsconfig.json
+     * manifest and can be considered as a typescript project.
+     */
+    public static isTypescriptProject(projectRoot: string): boolean {
+        return fs.existsSync(path.resolve(projectRoot, 'tsconfig.json'));
+    }
 }

--- a/src/utils/tsdHelper.ts
+++ b/src/utils/tsdHelper.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 import * as path from 'path';
+import * as fs from 'fs';
 import * as Q from 'q';
 import {TelemetryHelper} from './telemetryHelper';
 import {CordovaProjectHelper} from './cordovaProjectHelper';
@@ -28,6 +29,8 @@ export class TsdHelper {
      *                    installed (relative to <project_root>\.vscode\typings)
      */
     public static installTypings(typingsFolderPath: string, typeDefsPath: string[], projectRoot?: string): void {
+        let installedTypeDefs: string[] = [];
+
         TelemetryHelper.generate('addTypings', (generator) => {
             generator.add('addedTypeDefinitions', typeDefsPath, false);
             return Q.all(typeDefsPath.map((relativePath: string): Q.Promise<any> => {
@@ -50,8 +53,64 @@ export class TsdHelper {
                     }
                 }
 
-                return TsdHelper.installTypeDefinitionFile(src, dest);
+                return TsdHelper.installTypeDefinitionFile(src, dest)
+                // Save installed typedef to write them all at once later
+                .then(() => installedTypeDefs.push(dest));
             }));
+        })
+        .finally(() => {
+            if (installedTypeDefs.length === 0) return;
+
+            let typingsFolder = path.resolve(projectRoot, TsdHelper.USER_TYPINGS_FOLDERNAME);
+            let indexFile = path.resolve(typingsFolder, 'cordova-typings.d.ts');
+
+            // Ensure that the 'typings' folder exits; if not, create it
+            if (!CordovaProjectHelper.existsSync(typingsFolder)) {
+                CordovaProjectHelper.makeDirectoryRecursive(typingsFolder);
+            }
+
+            let references = CordovaProjectHelper.existsSync(indexFile) ? fs.readFileSync(indexFile, 'utf8') : [];
+            let referencesToAdd = installedTypeDefs
+                // Do not add references to typedefs that are not exist,
+                // this rarely happens if typedef file fails to copy
+                .filter(typeDef => CordovaProjectHelper.existsSync(typeDef))
+                .map(typeDef => path.relative(typingsFolder, typeDef))
+                // Avoid adding duplicates if reference already exist in index
+                .filter(typeDef => references.indexOf(typeDef) < 0)
+                .map(typeDef => `/// <reference path="${typeDef}"/>`);
+
+            if (referencesToAdd.length === 0) return;
+
+            fs.writeFileSync(indexFile, [references].concat(referencesToAdd).join('\n'), 'utf8');
         });
+    }
+
+    public static removeTypings(typingsFolderPath: string, typeDefsToRemove: string[], projectRoot: string): void {
+        if (typeDefsToRemove.length === 0) return;
+
+        typeDefsToRemove.forEach(typeDef => {
+            fs.unlink(path.resolve(typingsFolderPath, typeDef), err => {
+                if (err) console.error(err);
+            });
+        });
+
+        let references = [];
+        let indexFile = path.resolve(projectRoot, TsdHelper.USER_TYPINGS_FOLDERNAME, 'cordova-typings.d.ts');
+        try {
+            references = fs.readFileSync(indexFile, 'utf8').split('\n');
+        } catch (e) {
+            // We failed to read index file - it might not exist of
+            // blocked by other process - can't do anything here
+            return;
+        }
+
+        let referencesToPersist = references.filter(ref =>
+            // Filter out references that we need to delete
+            ref && !typeDefsToRemove.some(typedef => ref.indexOf(typedef) >= 0));
+
+        referencesToPersist.length === 0 ?
+            fs.unlink(indexFile) :
+            // Write filtered references back to index file
+            fs.writeFileSync(indexFile, referencesToPersist.join('\n'), 'utf8');
     }
 }


### PR DESCRIPTION
VSCode starting from 1.7.2 automatically provides typings for dependencies mentioned in package.json (in Cordova projects this usually happens when plugin has been installed using `--fetch` option) - in this case we can safely ignore own typings installation mechanism and rely on VSCode. Previous behavior is still retained for previous VSCode versions though.

This PR also disables installation of typings into Ionic 2 projects, because they are written in typescript and Ionic provides own set of TS wrappers around plugins.
