### PR TITLE
Output build logs for Ionic projects

### DIFF
--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -784,6 +784,7 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
 
         let serverOutputHandler = (data: Buffer) => {
             serverOut += data.toString();
+            this.outputLogger(data.toString(), "stdout");
 
             // Listen for the server to be ready. We check for the "Running dev server:  http://localhost:<port>/" and "dev server running: http://localhost:<port>/" strings to decide that.
             //


### PR DESCRIPTION
Output build logs for Ionic projects  which running with livereload or serving to the browser.  It works similar to output build logs for cordova projects (https://github.com/Microsoft/vscode-cordova/pull/212) 