### PR TITLE
Fix iOS 10 deploy and run problems

### DIFF
--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -521,7 +521,7 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
                     // device.url is of the form 'localhost:port'
                     return parseInt(device.url.split(':')[1], 10);
                 } catch (e) {
-                    throw new Error('Unable to find iOS target device/simulator. Try specifying a different "port" parameter in launch.json');
+                    throw new Error('Unable to find iOS target device/simulator. Please check that "Settings > Safari > Advanced > Web Inspector = ON" or try specifying a different "port" parameter in launch.json');
                 }
             }).then((targetPort) => {
                 let findWebviewFunc = () => {


### PR DESCRIPTION
iOS 10.2.1 (and maybe others) behaves differently  when GDB 'c' command is sent - instead of responding w/ '$OK' it sends an empty response which we skip. We'd need to listen to the empty responses too and continue execution in that case

This fixes #246 