### PR TITLE
Fix Regex for searching "localabstract" name of app under debug

### DIFF
--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -333,7 +333,7 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
                     .then((getSocketsResult) => {
                         const lines = getSocketsResult.split('\n');
                         for (const line of lines) {
-                            const fields = line.split(/[ \r]/);
+                            const fields = line.split(/[ \r]+/);
                             if (fields.length < 8) {
                                 continue;
                             }


### PR DESCRIPTION
This is a fix for the issue, described in #215. Though we were unable to repro the case when output of `cat /proc/net/unix` contains fields, delimited w/ multiple spaces, it still make sense to update the  Regex to fix the issue preventively (similar to what was suggested in https://github.com/Microsoft/vscode-cordova/issues/215#issuecomment-270289748)

This fixes #215