### PR TITLE
Suppress irrelevant stderr output from Ionic

### DIFF
--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -41,9 +41,16 @@ export function cordovaRunCommand(args: string[], cordovaRootPath: string): Q.Pr
     let output = '';
     let stderr = '';
     let process = cordovaStartCommand(args, cordovaRootPath);
+    // suppress the following strings because they are not actual errors:
+    let stringsToSuppress = ['Run an Ionic project on a connected device'];
 
     process.stderr.on('data', data => {
         stderr += data.toString();
+        for (var i = 0; i < stringsToSuppress.length; i++) {
+            if (data.toString().indexOf(stringsToSuppress[i]) >= 0) {
+                return;
+            }
+        }
         defer.notify([data.toString(), 'stderr']);
     });
     process.stdout.on('data', data => {


### PR DESCRIPTION
After recent introduction of continuous logs (https://github.com/Microsoft/vscode-cordova/pull/266) some irrelevant stderr output from Ionic has appeared in console. This output is present even in clean ionic project and you can see it by running `ionic run android --verbose`. These changes aim to suppress this irrelevant part:
```
Task: title=run, name=run, summary=Run an Ionic project on a connected device, <PLATFORM>=, [options]=, --livereload|-l=Live reload app dev files from the device (beta), --address=Use specific address (livereload req.), --port|-p=Dev server HTTP port (8100 default, livereload req.), --livereload-port|-r=Live Reload port (35729 default, livereload req.), title=Print app console logs to Ionic CLI (livereload req.), boolean=true, title=Print dev server logs to Ionic CLI (livereload req.), boolean=true, title=, boolean=true, --device|--emulator|--target=FOO=, isProjectTask=true, run=function run(ionic, argv, rawCliArguments) {
  var appDirectory = process.cwd();
  var rawArgs = rawCliArguments.slice(0);
  var cmdName = argv._[0].toLowerCase();
  var hasBuildCommand = false;
  var hasServeCommand = false;

  var isLiveReload = argv.livereload || argv['live-reload'] || argv.l || false;

  // If platform was not passed then add it to the rawArgs
  var runPlatform = argv._[1];
  if (!runPlatform) {
    runPlatform = 'ios';
    rawArgs.splice(1, 0, runPlatform);
  }

  if (runPlatform === 'ios' && os.platform() !== 'darwin') {
    log.error('✗ You cannot run iOS unless you are on Mac OSX.');
    return Q();
  }

  var promiseList = []
    .concat(!cordovaUtils.isPlatformInstalled(runPlatform, appDirectory) ?
      cordovaUtils.installPlatform(runPlatform) :
      Q())
    .concat(!cordovaUtils.arePluginsInstalled(appDirectory) ?
      cordovaUtils.installPlugins() :
      Q())
    .concat(npmScripts.hasIonicScript('build'))
    .concat(npmScripts.hasIonicScript('serve'));

  return Q.all(promiseList).then(function(results) {
    hasBuildCommand = results[2];
    hasServeCommand = results[3];

    if (hasBuildCommand && !(isLiveReload && hasServeCommand)) {
      return npmScripts.runIonicScript('build', rawArgs.slice(2));
    }
    return Q();
  })
  .then(function() {

    // If we are running livereload and are using "ionic:serve" app-script
    // then configure devServer manually
    if (isLiveReload && hasServeCommand) {

      // using app-scripts and livereload is requested
      // Also remove commandName from the rawArgs passed
      return cordovaUtils.startAppScriptsServer(argv);
    } else if (isLiveReload) {

      // not an app-scripts project but the user wants livereload
      return cordovaUtils.setupLiveReload(argv, appDirectory);
    }

    // ensure the content node was set back to its original
    return ConfigXml.setConfigXml(appDirectory, {
      resetContent: true,
      errorWhenNotFound: false
    });
  })
  .then(function(serveOptions) {
    var optionList = cordovaUtils.filterArgumentsForCordova(cmdName, argv, rawArgs);
    return cordovaUtils.execCordovaCommand(optionList, isLiveReload, serveOptions);
  })
  .catch(function(ex) {
    if (ex instanceof Error) {
      log.error(ex);
    }
  });
}
```