### PR TITLE
Ignore "cordova build/run" commands while debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,14 @@
       {
         "command": "cordova.build",
         "key": "f6",
-        "mac": "f6"
+        "mac": "f6",
+        "when": "!inDebugMode"
       },
       {
         "command": "cordova.run",
         "key": "ctrl+f5",
-        "mac": "cmd+f5"
+        "mac": "cmd+f5",
+        "when": "!inDebugMode"
       }
     ],
     "debuggers": [


### PR DESCRIPTION
As suggested in #222  user would hardly ever want to call `cordova build` or `cordova run` command during debug session, so we'd need to run those conditionally by adding `when` clause to `contributes/keybindings` section

This closes #222