### PR TITLE
Add support for `ionic cordova` namespaced commands updated on CLIv3

### DIFF
--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -78,6 +78,12 @@ export function cordovaStartCommand(args: string[], cordovaRootPath: string): ch
     let cliName = CordovaProjectHelper.isIonicProject(cordovaRootPath) ? 'ionic' : 'cordova';
     let commandExtension = os.platform() === 'win32' ? '.cmd' : '';
     let command = cliName + commandExtension;
+
+    if (CordovaProjectHelper.isIonicCordovaCLINamespacedProject(cordovaRootPath)) {
+        // add cordova namespace to Ionic projects that uses cli-plugin-cordova
+        args.unshift('cordova');
+    }
+
     return child_process.spawn(command, args, { cwd: cordovaRootPath });
 }
 

--- a/src/utils/cordovaProjectHelper.ts
+++ b/src/utils/cordovaProjectHelper.ts
@@ -303,6 +303,23 @@ export class CordovaProjectHelper {
     }
 
     /**
+     *  Helper function to determine whether the project is an Ionic project using cli-plugin-cordova that add Cordova commands to an namespace
+     */
+    public static isIonicCordovaCLINamespacedProject(projectRoot: string): boolean {
+        // First look if is an Ionic project, because cli-plugin-cordova didn't depend which Ionic version of project
+        if (CordovaProjectHelper.isIonicProject(projectRoot)) {
+            const packageJsonPath = path.join(projectRoot, 'package.json');
+            if (!fs.existsSync(packageJsonPath)) {
+                return false;
+            }
+            const devDependencies = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')).devDependencies;
+
+            return !!(devDependencies && devDependencies['@ionic/cli-plugin-cordova']);
+        }
+        return false;
+    }
+
+    /**
      * Helper function to determine whether the project has a tsconfig.json
      * manifest and can be considered as a typescript project.
      */


### PR DESCRIPTION
In a try to add support for [newly changes on Ionic CLI v3](https://github.com/driftyco/ionic-cli#changes-from-cli-2) that adds Cordova commands to an namespace, I've added an helper that checks presence of new `@ionic/cordova-cli-plugin`([CHANGELOG](https://github.com/driftyco/ionic-cli/blob/master/CHANGELOG.md)) in dev dependencies. 

That helper is used for prepend `"cordova"` namespace on args when starting Cordova command.

I hope that I've contribute until here. 

This fixes #279