### PR TITLE
Fix to not prepend 'cordova' argument when running ionic serve.

### DIFF
--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -79,7 +79,9 @@ export function cordovaStartCommand(args: string[], cordovaRootPath: string): ch
     let commandExtension = os.platform() === 'win32' ? '.cmd' : '';
     let command = cliName + commandExtension;
 
-    if (CordovaProjectHelper.isIonicCordovaCLINamespacedProject(cordovaRootPath)) {
+    let isIonicServe:boolean = args.indexOf("serve") >= 0;
+
+    if (CordovaProjectHelper.isIonicCordovaCLINamespacedProject(cordovaRootPath) && !isIonicServe) {
         // add cordova namespace to Ionic projects that uses cli-plugin-cordova
         args.unshift('cordova');
     }


### PR DESCRIPTION
The previous change adds a 'cordova' argument to all debugging command lines. This works for all cases except when running ionic serve (simulate in a browser). That fails when you attempt to run with the current code base. This change addresses that. 

I looked at https://ionicframework.com/docs/cli/ to see if any other debugging CLI commands would make sense to not include the 'cordova' argument, but it seems like serve is the only one.