### PR TITLE
Do not install cordova typings in typescript projects

### DIFF
--- a/src/cordova.ts
+++ b/src/cordova.ts
@@ -141,8 +141,15 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
     }
 
-    // Install the type defintion files for Cordova
-    TsdHelper.installTypings(CordovaProjectHelper.getOrCreateTypingsTargetPath(cordovaProjectRoot), [pluginTypings[CORDOVA_TYPINGS_QUERYSTRING].typingFile], cordovaProjectRoot);
+    // Skip adding typings for cordova in case of Typescript or Ionic2 projects
+    // to avoid conflicts between typings we install and user-installed ones.
+    if (!CordovaProjectHelper.isIonic2Project(cordovaProjectRoot) &&
+        !CordovaProjectHelper.isTypescriptProject(cordovaProjectRoot)) {
+
+        // Install the type defintion files for Cordova
+        TsdHelper.installTypings(CordovaProjectHelper.getOrCreateTypingsTargetPath(cordovaProjectRoot),
+            [pluginTypings[CORDOVA_TYPINGS_QUERYSTRING].typingFile], cordovaProjectRoot);
+    }
 
     // Install type definition files for the currently installed plugins
     updatePluginTypeDefinitions(cordovaProjectRoot);


### PR DESCRIPTION
To avoid compilation errors due to duplicated symbols we need to skip cordova typings installation in case of existing typescript project (`tsconfig.json` is present) - the same approach is already used to decide whether to install plugin typings.

This fixes #299 