### PR TITLE
Fix ionic version detection

### DIFF
--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -103,7 +103,7 @@ export function cordovaStartCommand(args: string[], cordovaRootPath: string): ch
 
     if (cliName === 'ionic' && !isIonicServe) {
         try {
-            let ionicInfo = child_process.spawnSync(command, ['-v'], {
+            let ionicInfo = child_process.spawnSync(command, ['-v', '--quiet'], {
                 cwd: cordovaRootPath
             });
             let ionicVersion = ionicInfo.stdout.toString().trim();


### PR DESCRIPTION
Ionic 3 asks about update if it's available like that
```The Ionic CLI has an update available (3.13.2 => 3.14.0)! Would you like to install it?```
it breaks version detection