### PR TITLE
Allow "non Ionic-CLI projects" to use the extension even with ionic-angular installed

### DIFF
--- a/src/utils/cordovaProjectHelper.ts
+++ b/src/utils/cordovaProjectHelper.ts
@@ -285,10 +285,11 @@ export class CordovaProjectHelper {
         if (!fs.existsSync(packageJsonPath)) {
             return false;
         }
-        const dependencies = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')).dependencies;
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+        const dependencies = packageJson.dependencies;
+        const devDependencies = packageJson.devDependencies;
         const highestNotSupportedIonic2BetaVersion = "2.0.0-beta.9";
-
-        if (!!(dependencies && dependencies["ionic-angular"])) {
+        if ((!!(dependencies && dependencies["ionic-angular"])) && (!!(devDependencies && devDependencies["@ionic/app-scripts"]))) {
             const ionicVersion = dependencies["ionic-angular"];
             // If it's a valid version let's check it's greater than 2.0.0-beta-9
             if (semver.valid(ionicVersion)) {

--- a/src/utils/cordovaProjectHelper.ts
+++ b/src/utils/cordovaProjectHelper.ts
@@ -286,11 +286,10 @@ export class CordovaProjectHelper {
             return false;
         }
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-        const dependencies = packageJson.dependencies;
-        const devDependencies = packageJson.devDependencies;
+        const dependencies = packageJson.dependencies || {};
+        const devDependencies = packageJson.devDependencies || {};
         const highestNotSupportedIonic2BetaVersion = "2.0.0-beta.9";
-        if ((!!(dependencies && dependencies["ionic-angular"])) &&
-            ((!!(devDependencies && devDependencies["@ionic/app-scripts"]))) || (!!(dependencies && dependencies["@ionic/app-scripts"]))) {
+        if ((dependencies["ionic-angular"]) && (devDependencies["@ionic/app-scripts"] || dependencies["@ionic/app-scripts"])) {
             const ionicVersion = dependencies["ionic-angular"];
             // If it's a valid version let's check it's greater than 2.0.0-beta-9
             if (semver.valid(ionicVersion)) {

--- a/src/utils/cordovaProjectHelper.ts
+++ b/src/utils/cordovaProjectHelper.ts
@@ -289,7 +289,8 @@ export class CordovaProjectHelper {
         const dependencies = packageJson.dependencies;
         const devDependencies = packageJson.devDependencies;
         const highestNotSupportedIonic2BetaVersion = "2.0.0-beta.9";
-        if ((!!(dependencies && dependencies["ionic-angular"])) && (!!(devDependencies && devDependencies["@ionic/app-scripts"]))) {
+        if ((!!(dependencies && dependencies["ionic-angular"])) &&
+            ((!!(devDependencies && devDependencies["@ionic/app-scripts"]))) || (!!(dependencies && dependencies["@ionic/app-scripts"]))) {
             const ionicVersion = dependencies["ionic-angular"];
             // If it's a valid version let's check it's greater than 2.0.0-beta-9
             if (semver.valid(ionicVersion)) {


### PR DESCRIPTION
This PR allow projects who have `ionic-angular` package _(to use only the ui components)_ but not the ionic-cli (to build) to use the extension.
Ex: Angular CLI projects with `ionic-angular` installed.