### PR TITLE
Launch simulator in external browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -453,6 +453,12 @@
             "default": [],
             "description": "Run arguments to be passed to 'cordova run/build <platform>' or 'ionic serve' command",
             "scope": "resource"
+          },
+          "cordova.simulatorInExternalBrowser": {
+            "type": "boolean",
+            "default": false,
+            "description": "Launch Cordova simulator in browser instead of tab in VS Code",
+            "scope": "resource"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -387,6 +387,11 @@
               "runArguments": {
                 "type": "array",
                 "description": "Run arguments to be passed to 'cordova run/build <platform>' or 'ionic serve' command(Override all other configuration params)"
+              },
+              "simulatorInExternalBrowser": {
+                "type": "boolean",
+                "description": "Launch Cordova simulator in browser instead of tab in VS Code",
+                "default": false
               }
             }
           },

--- a/src/common/extensionMessaging.ts
+++ b/src/common/extensionMessaging.ts
@@ -17,7 +17,8 @@ export enum ExtensionMessage {
     SEND_TELEMETRY,
     SIMULATE,
     START_SIMULATE_SERVER,
-    GET_RUN_ARGUMENTS
+    GET_RUN_ARGUMENTS,
+    GET_SIMULATOR_IN_EXTERNAL_BROWSER_SETTING
 }
 
 export interface MessageWithArguments {

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -693,11 +693,20 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
                 simulateInfo = simInfo;
                 return this.connectSimulateDebugHost(simulateInfo);
             }).then(() => {
-                return messageSender.sendMessage(messaging.ExtensionMessage.LAUNCH_SIM_HOST, [launchArgs.cwd]);
+                launchArgs.userDataDir = path.join(settingsHome(), CordovaDebugAdapter.CHROME_DATA_DIR);
+                return CordovaDebugAdapter.getSimulatorInExternalBrowserSetting(launchArgs.cwd)
+                    .then(simulatorInExternalBrowser => {
+                        if (simulatorInExternalBrowser) {
+                            return this.launchChrome({
+                                ...launchArgs,
+                                url: simulateInfo.simHostUrl
+                            });
+                        }
+                        return messageSender.sendMessage(messaging.ExtensionMessage.LAUNCH_SIM_HOST, [launchArgs.cwd]);
+                    });
             }).then(() => {
                 // Launch Chrome and attach
                 launchArgs.url = simulateInfo.appHostUrl;
-                launchArgs.userDataDir = path.join(settingsHome(), CordovaDebugAdapter.CHROME_DATA_DIR);
                 this.outputLogger('Attaching to app');
 
                 return this.launchChrome(launchArgs);
@@ -1283,5 +1292,9 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
 
     public static getRunArguments(projectRoot: string): Q.Promise<string[]> {
         return new messaging.ExtensionMessageSender(projectRoot).sendMessage(messaging.ExtensionMessage.GET_RUN_ARGUMENTS, [projectRoot]);
+    }
+
+    public static getSimulatorInExternalBrowserSetting(projectRoot: string): Q.Promise<boolean> {
+        return new messaging.ExtensionMessageSender(projectRoot).sendMessage(messaging.ExtensionMessage.GET_SIMULATOR_IN_EXTERNAL_BROWSER_SETTING, [projectRoot]);
     }
 }

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -37,6 +37,7 @@ export class ExtensionServer implements vscode.Disposable {
         this.messageHandlerDictionary[ExtensionMessage.START_SIMULATE_SERVER] = this.launchSimulateServer;
         this.messageHandlerDictionary[ExtensionMessage.GET_VISIBLE_EDITORS_COUNT] = this.getVisibleEditorsCount;
         this.messageHandlerDictionary[ExtensionMessage.GET_RUN_ARGUMENTS] = this.getRunArguments;
+        this.messageHandlerDictionary[ExtensionMessage.GET_SIMULATOR_IN_EXTERNAL_BROWSER_SETTING] = this.getSimulatorInExternalBrowserSetting;
     }
 
     /**
@@ -183,5 +184,9 @@ export class ExtensionServer implements vscode.Disposable {
 
     private getRunArguments(fsPath: string): Q.Promise<string[]> {
         return Q.resolve(CordovaCommandHelper.getRunArguments(fsPath));
+    }
+
+    private getSimulatorInExternalBrowserSetting(fsPath: string): Q.Promise<boolean> {
+        return Q.resolve(CordovaCommandHelper.getSimulatorInExternalBrowserSetting(fsPath));
     }
 }

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -94,7 +94,7 @@ export class ExtensionServer implements vscode.Disposable {
     private simulate(fsPath: string, simulateOptions: SimulateOptions, projectType: IProjectType): Q.Promise<SimulationInfo> {
         return this.launchSimulateServer(fsPath, simulateOptions, projectType)
             .then((simulateInfo: SimulationInfo) => {
-               return this.launchSimHost(fsPath).then(() => simulateInfo);
+               return this.launchSimHost(fsPath, simulateOptions.target).then(() => simulateInfo);
             });
     }
 
@@ -110,8 +110,8 @@ export class ExtensionServer implements vscode.Disposable {
     /**
      * Launches sim-host using an already running simulate server.
      */
-    private launchSimHost(fsPath: string): Q.Promise<void> {
-        return this.pluginSimulator.launchSimHost(fsPath);
+    private launchSimHost(fsPath: string, target: string, runInBrowser?: boolean): Q.Promise<void> {
+        return this.pluginSimulator.launchSimHost(fsPath, target, runInBrowser);
     }
 
     /**

--- a/src/utils/cordovaCommandHelper.ts
+++ b/src/utils/cordovaCommandHelper.ts
@@ -82,13 +82,18 @@ export class CordovaCommandHelper {
      * Get command line run arguments from settings.json
      */
     public static getRunArguments(fsPath: string): string[] {
-        let uri = Uri.file(fsPath);
-        const workspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration("cordova", uri);
-        const configKey: string = 'runArguments';
-        if (workspaceConfiguration.has(configKey)) {
-            return ConfigurationReader.readArray(workspaceConfiguration.get(configKey));
-        }
+        return CordovaCommandHelper.getSetting(fsPath, 'runArguments') || [];
+    }
 
-        return [];
+    public static getSimulatorInExternalBrowserSetting(fsPath: string): boolean {
+        return CordovaCommandHelper.getSetting(fsPath, 'simulatorInExternalBrowser') === true;
+    }
+
+    private static getSetting(fsPath: string, configKey: string): any {
+        let uri = Uri.file(fsPath);
+        const workspaceConfiguration: WorkspaceConfiguration = workspace.getConfiguration('cordova', uri);
+        if (workspaceConfiguration.has(configKey)) {
+            return workspaceConfiguration.get(configKey);
+        }
     }
 }


### PR DESCRIPTION
Adds `cordova.simulatorInExternalBrowser` setting that makes Cordova simulator to launch in default browser instead of tab in VS Code
Requested in #338