### PR TITLE
Fix ionic nightly version detection

### DIFF
--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -108,7 +108,11 @@ export function cordovaStartCommand(args: string[], cordovaRootPath: string): ch
                 cwd: cordovaRootPath
             });
             let ionicVersion = ionicInfo.stdout.toString().trim();
-            if (semver.gte(ionicVersion, '3.0.0')) {
+
+            // Assuming for now that latest version is > 3
+            const isLatestIonic = (ionicVersion === 'latest' || ionicVersion === 'nightly');
+
+            if (isLatestIonic || semver.gte(ionicVersion, '3.0.0')) {
                 args.unshift('cordova');
             }
         } catch (err) {

--- a/src/utils/cordovaProjectHelper.ts
+++ b/src/utils/cordovaProjectHelper.ts
@@ -291,6 +291,12 @@ export class CordovaProjectHelper {
         const highestNotSupportedIonic2BetaVersion = "2.0.0-beta.9";
         if ((dependencies["ionic-angular"]) && (devDependencies["@ionic/app-scripts"] || dependencies["@ionic/app-scripts"])) {
             const ionicVersion = dependencies["ionic-angular"];
+
+            // Assuming for now that latest version is > 3
+            if (ionicVersion === 'latest' || ionicVersion === 'nightly') {
+                return true;
+            }
+
             // If it's a valid version let's check it's greater than 2.0.0-beta-9
             if (semver.valid(ionicVersion)) {
                 return semver.gt(ionicVersion, highestNotSupportedIonic2BetaVersion);


### PR DESCRIPTION
As reported in #134, Ionic version detection fails for `nightly`. This PR assumes that `nightly` and `latest` is Ionic > 3.0.0