### PR TITLE
Fixed isDirectory() function

### DIFF
--- a/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/code-signing/hash-utils.ts
+++ b/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/code-signing/hash-utils.ts
@@ -83,7 +83,11 @@ export class PackageManifest {
 }
 
 export async function generatePackageHashFromDirectory(directoryPath: string, basePath: string): Promise<string> {
-  if (!fileUtils.isDirectory(directoryPath)) {
+  try {
+    if (!fileUtils.isDirectory(directoryPath)) {
+      throw new Error('Not a directory. Please either create a directory, or use hashFile().');
+    }
+  } catch (error) {
     throw new Error('Not a directory. Please either create a directory, or use hashFile().');
   }
 

--- a/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/code-signing/sign.ts
+++ b/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/code-signing/sign.ts
@@ -30,8 +30,12 @@ export default async function sign(privateKeyPath: string, updateContentsPath: s
   }
 
   // If releasing a single file, copy the file to a temporary "CodePush" directory in which to publish the release
-  if (!fileUtils.isDirectory(updateContentsPath)) {
-    updateContentsPath = fileUtils.copyFileToTmpDir(updateContentsPath);
+  try {
+    if (!fileUtils.isDirectory(updateContentsPath)) {
+      updateContentsPath = fileUtils.copyFileToTmpDir(updateContentsPath);
+    }
+  } catch (error) {
+    Promise.reject(error);
   }
 
   signatureFilePath = path.join(updateContentsPath, METADATA_FILE_NAME);

--- a/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/zip.ts
+++ b/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/zip.ts
@@ -29,7 +29,6 @@ export default function zip(updateContentsPath: string, outputDir?: string): Pro
       reject(error);
     }
 
-
     const directoryPath: string = updateContentsPath;
     const baseDirectoryPath = path.join(directoryPath, '..'); // For legacy reasons, put the root directory in the zip
 

--- a/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/zip.ts
+++ b/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/zip.ts
@@ -25,7 +25,7 @@ export default function zip(updateContentsPath: string, outputDir?: string): Pro
         });
       }
     } catch (error) {
-      error.message = error.message + " Make sure you have run `cordova platform add ios`.";
+      error.message = error.message + " Make sure you have run `cordova platform add <platform name>`.";
       reject(error);
     }
 

--- a/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/zip.ts
+++ b/src/extension/appcenter/codepush/codepush-sdk/src/update-contents/zip.ts
@@ -17,12 +17,18 @@ export default function zip(updateContentsPath: string, outputDir?: string): Pro
   return new Promise<string>(async (resolve, reject) => {
     const releaseFiles: ReleaseFile[] = [];
 
-    if (!fileUtils.isDirectory(updateContentsPath)) {
-      releaseFiles.push({
-        sourceLocation: updateContentsPath,
-        targetLocation: fileUtils.normalizePath(path.basename(updateContentsPath)), // Put the file in the root
-      });
+    try {
+      if (!fileUtils.isDirectory(updateContentsPath)) {
+        releaseFiles.push({
+          sourceLocation: updateContentsPath,
+          targetLocation: fileUtils.normalizePath(path.basename(updateContentsPath)), // Put the file in the root
+        });
+      }
+    } catch (error) {
+      error.message = error.message + " Make sure you have run `cordova platform add ios`.";
+      reject(error);
     }
+
 
     const directoryPath: string = updateContentsPath;
     const baseDirectoryPath = path.join(directoryPath, '..'); // For legacy reasons, put the root directory in the zip


### PR DESCRIPTION
`fileUtils.isDirectory()` throws error if no such directory (f. e. platform has not been added), this error is not handled and makes everything get stuck.