### PR TITLE
Remove local app-center-node-client dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,13 +66,20 @@ var projectConfig = {
     typescript: typescript
 };
 
-gulp.task('build', function () {
+gulp.task('build-tsc', function () {
     return gulp.src(sources, { base: '.' })
         .pipe(sourcemaps.init())
         .pipe(ts(projectConfig))
         .pipe(sourcemaps.write('.', { includeContent: false, sourceRoot: __dirname }))
         .pipe(gulp.dest('out'));
 });
+
+gulp.task('copy-lib', function () {
+    return gulp.src('src/extension/appcenter/lib/**/*{.d.ts,.js}', { base: '.' })
+        .pipe(gulp.dest('out'));
+});
+
+gulp.task('build', ['build-tsc', 'copy-lib']);
 
 gulp.task('watch', ['build'], function(cb) {
     log('Watching build sources...');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -527,12 +527,6 @@
         }
       }
     },
-    "app-center-node-client": {
-      "version": "file:src/extension/appcenter/lib/app-center-node-client",
-      "requires": {
-        "ms-rest": "2.3.1"
-      }
-    },
     "append-transform": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -556,12 +556,10 @@
   "scripts": {
     "compile": "node ./node_modules/gulp/bin/gulp",
     "test": "node ./node_modules/mocha/bin/mocha --recursive -u bdd ./out/test/debugger",
-    "preinstall": "npm install ./src/extension/appcenter/lib/app-center-node-client",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "vscode:prepublish": "gulp"
   },
   "dependencies": {
-    "app-center-node-client": "file:src/extension/appcenter/lib/app-center-node-client",
     "chalk": "^2.3.0",
     "cordova-simulate": "^0.3.0",
     "crypto": "^1.0.1",

--- a/src/extension/appcenter/api/appCenterClientCredentials.ts
+++ b/src/extension/appcenter/api/appCenterClientCredentials.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-import AppCenterClientCredentials = require('app-center-node-client/src/appCenterClientCredentials');
+import AppCenterClientCredentials = require('../lib/app-center-node-client/src/appCenterClientCredentials');
 export { AppCenterClientCredentials };
 

--- a/src/extension/appcenter/api/createClient.ts
+++ b/src/extension/appcenter/api/createClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-import AppCenterClient from 'app-center-node-client';
+import AppCenterClient from '../lib/app-center-node-client/index';
 import { AppCenterClientCredentials } from './appCenterClientCredentials';
 import * as Q from 'q';
 import { Profile } from '../auth/profile/profile';

--- a/src/extension/appcenter/api/index.ts
+++ b/src/extension/appcenter/api/index.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-import AppCenterClient from 'app-center-node-client';
-import * as models from 'app-center-node-client/models';
+import AppCenterClient from '../lib/app-center-node-client';
+import * as models from '../lib/app-center-node-client/models';
 
 export { AppCenterClient, models };
 export { AppCenterClientFactory, createAppCenterClient, getQPromisifiedClientResult } from './createClient';

--- a/src/extension/appcenter/auth/auth.ts
+++ b/src/extension/appcenter/auth/auth.ts
@@ -5,7 +5,7 @@ import * as Q from 'q';
 import { SettingsHelper } from '../../../utils/settingsHelper';
 import { createAppCenterClient, getQPromisifiedClientResult } from '../api/index';
 import { Profile, saveUser, deleteUser, getUser } from '../auth/profile/profile';
-import * as models from 'app-center-node-client/models';
+import * as models from '../lib/app-center-node-client/models';
 
 export default class Auth {
     public static getProfile(projectRootPath: string): Q.Promise<Profile | null> {


### PR DESCRIPTION
This PR removes local `app-center-node-client` from dependencies for consistency with https://github.com/Microsoft/vscode-react-native/pull/655.