### PR TITLE
Disable run on ios simulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To start the debugger, choose a target from the target drop-down list, and then 
 
 ![Cordova launch targets](images/debug-targets.png)
 
-You can debug your app on an Android emulator or a Android/iOS device. If you have your app running in one already, you can attach the debugger to it. The debugger uses the application ID of your project to locate the running instance.
+You can debug your app on an Android emulator or an Android/iOS device. If you have your app running in one already, you can attach the debugger to it. The debugger uses the application ID of your project to locate the running instance.
 
 > **Visual Studio Emulator for Android:**
 To deploy your app to the Visual Studio Emulator for Android using our extension, you first need to manually launch the emulator. Once it is running, select the ```Run Android on Device``` debug target rather than the emulator target. If *ADB* didn't automatically recognize the VS Android emulator when you launched it, you will need to run ```adb connect [EMULATOR'S IP]``` on the command prompt before trying to deploy. To find out the IP address of your emulator, click the double arrow icon at the bottom of the emulator's side-menu to open the "Additional Tools" window, and go to the "Network" tab. Use the IP of an appropriate network adapter in the list.
@@ -208,7 +208,7 @@ If you don’t wish to send usage data to Microsoft, please follow the instructi
 
 * Why can't I debug on iOS Simulator?
 
-Apple removed option to enable WebInspector inside simulator and debug proxy unable to connect to application webview and that's why debugging on iOS simulators is not yet available. As soon as Apple publish new way to connect to simulators, debugging won iOS simulators ill be returned.
+Apple removed option to enable WebInspector inside simulator and debug proxy unable to connect to application webview and that's why debugging on iOS simulators is not yet available. As soon as Apple publish new way to connect to simulators, debugging on iOS simulators will be returned.
 
 *  Error `Error: Project does not include the specified platform: android` while running `Simulate android in browser` on Ubuntu machine.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To start the debugger, choose a target from the target drop-down list, and then 
 
 ![Cordova launch targets](images/debug-targets.png)
 
-You can debug your app on an Android emulator, iOS simulator, or a device. If you have your app running in one already, you can attach the debugger to it. The debugger uses the application ID of your project to locate the running instance.
+You can debug your app on an Android emulator or a Android/iOS device. If you have your app running in one already, you can attach the debugger to it. The debugger uses the application ID of your project to locate the running instance.
 
 > **Visual Studio Emulator for Android:**
 To deploy your app to the Visual Studio Emulator for Android using our extension, you first need to manually launch the emulator. Once it is running, select the ```Run Android on Device``` debug target rather than the emulator target. If *ADB* didn't automatically recognize the VS Android emulator when you launched it, you will need to run ```adb connect [EMULATOR'S IP]``` on the command prompt before trying to deploy. To find out the IP address of your emulator, click the double arrow icon at the bottom of the emulator's side-menu to open the "Additional Tools" window, and go to the "Network" tab. Use the IP of an appropriate network adapter in the list.
@@ -206,9 +206,9 @@ If you don’t wish to send usage data to Microsoft, please follow the instructi
 
 ## Known Issues
 
-* Error `Unable to find webview` while debugging on iOS Simulator
+* Why can't I debug on iOS Simulator?
 
-This is [ios-webkit-debug-proxy issue](https://github.com/google/ios-webkit-debug-proxy/issues/250). Apple removed option to enable WebInspector inside simulator and debug proxy unable to connect to application webview.
+Apple removed option to enable WebInspector inside simulator and debug proxy unable to connect to application webview and that's why debugging on iOS simulators is not yet available. As soon as Apple publish new way to connect to simulators, debugging won iOS simulators ill be returned.
 
 *  Error `Error: Project does not include the specified platform: android` while running `Simulate android in browser` on Ubuntu machine.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       }
     },
     "acorn": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -584,7 +584,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-initial": {
@@ -723,7 +723,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -1051,7 +1051,7 @@
     },
     "browser-pack": {
       "version": "6.1.0",
-      "resolved": "http://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "requires": {
         "JSONStream": "^1.0.3",
@@ -1149,7 +1149,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -1183,7 +1183,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -1580,7 +1580,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
@@ -1621,7 +1621,7 @@
     },
     "cordova-registry-mapper": {
       "version": "1.1.15",
-      "resolved": "http://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/cordova-registry-mapper/-/cordova-registry-mapper-1.1.15.tgz",
       "integrity": "sha1-4kS5GFuBdUc7/2B5MkkFEV+D3Hw="
     },
     "cordova-serve": {
@@ -1637,9 +1637,9 @@
       }
     },
     "cordova-simulate": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cordova-simulate/-/cordova-simulate-0.6.0.tgz",
-      "integrity": "sha512-qVdQTn2mQ1OU0GUxQ26AKN3jl0FxK5EZJBLKNarmwvonTdHONyt8WO1Wxnl9JV0cVzSOCjukiJlMGHdVjby8Xg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cordova-simulate/-/cordova-simulate-0.6.1.tgz",
+      "integrity": "sha512-PPm8ZebzPhNTerxNdSBbY5zl28aYlF8eenuilBsg0Tnku2AIZIMYOCwfjvkGOtwCtqL4B2DovQbkt2A9FN5mZQ==",
       "requires": {
         "browserify": "^16.2.3",
         "chalk": "^1.1.1",
@@ -1651,7 +1651,7 @@
         "ncp": "^2.0.0",
         "q": "^1.4.1",
         "replacestream": "^4.0.0",
-        "send-transform": "0.15.0",
+        "send-transform": "^0.15.1",
         "socket.io": "^2.2.0",
         "through2": "^2.0.0"
       },
@@ -1663,7 +1663,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -1675,7 +1675,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
@@ -1696,7 +1696,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1708,7 +1708,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1983,7 +1983,7 @@
     },
     "deps-sort": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "requires": {
         "JSONStream": "^1.0.3",
@@ -2040,7 +2040,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -2198,14 +2198,6 @@
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
-          }
-        },
-        "ws": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-          "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
-          "requires": {
-            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -2551,7 +2543,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -2991,7 +2983,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3012,12 +3005,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3032,17 +3027,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3159,7 +3157,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3171,6 +3170,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3185,6 +3185,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3192,12 +3193,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3216,6 +3219,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3296,7 +3300,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3308,6 +3313,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3393,7 +3399,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3429,6 +3436,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3448,6 +3456,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3491,12 +3500,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3796,7 +3807,7 @@
     },
     "globby": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
@@ -4888,7 +4899,7 @@
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E="
     },
     "htmlparser2": {
@@ -4935,7 +4946,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -5405,7 +5416,7 @@
     },
     "labeled-stream-splicer": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
       "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "requires": {
         "inherits": "^2.0.1",
@@ -6017,7 +6028,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
@@ -6389,7 +6400,7 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
     },
     "negotiator": {
@@ -6742,15 +6753,16 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
-      "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+      "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
       "requires": {
         "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
         "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3"
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "parse-filepath": {
@@ -7812,9 +7824,9 @@
       }
     },
     "send-transform": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/send-transform/-/send-transform-0.15.0.tgz",
-      "integrity": "sha512-uSeM5EDEhE/wN904MKSBgjnRFDwlZ4id46gzmvnWHk8OX+YVZCXH4ed85VH1kuFSibir3xaEdJqwUeK6riZsIw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/send-transform/-/send-transform-0.15.1.tgz",
+      "integrity": "sha512-Ct8UZIBUFO9YqThQ4nnlwAzgLycGG71B9C0td+eEzUxrxvJO+qICxpUJdkflRKHbXM3PmnMtjDZ9U9blra/Mnw==",
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.0",
@@ -7825,7 +7837,7 @@
         "fresh": "0.5.2",
         "http-errors": "~1.5.0",
         "mime": "1.6.0",
-        "ms": "0.7.1",
+        "ms": "2.1.1",
         "on-finished": "~2.3.0",
         "range-parser": "~1.2.0",
         "statuses": "~1.3.0"
@@ -7838,7 +7850,7 @@
         },
         "http-errors": {
           "version": "1.5.1",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
           "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
           "requires": {
             "inherits": "2.0.3",
@@ -7852,9 +7864,9 @@
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "ms": {
-          "version": "0.7.1",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "setprototypeof": {
           "version": "1.0.2",
@@ -7915,7 +7927,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -7924,7 +7936,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "requires": {
         "json-stable-stringify": "~0.0.0",
@@ -8419,7 +8431,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
         "inherits": "~2.0.1",
@@ -8468,7 +8480,7 @@
     },
     "stream-splicer": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "requires": {
         "inherits": "^2.0.1",
@@ -8552,7 +8564,7 @@
     },
     "syntax-error": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "requires": {
         "acorn-node": "^1.2.0"
@@ -8599,7 +8611,7 @@
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "requires": {
         "process": "~0.11.0"
@@ -9493,6 +9505,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
+      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
     },
     "xmlbuilder": {
       "version": "8.2.2",

--- a/package.json
+++ b/package.json
@@ -547,7 +547,7 @@
     "vscode:prepublish": "gulp"
   },
   "dependencies": {
-    "cordova-simulate": "^0.6.0",
+    "cordova-simulate": "^0.6.1",
     "elementtree": "^0.1.6",
     "plist": "^2.0.1",
     "q": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -153,33 +153,12 @@
             "ionicLiveReload": false
           },
           {
-            "name": "Run iOS on simulator",
-            "type": "cordova",
-            "request": "launch",
-            "platform": "ios",
-            "target": "emulator",
-            "port": 9220,
-            "sourceMaps": true,
-            "cwd": "${workspaceFolder}",
-            "ionicLiveReload": false
-          },
-          {
             "name": "Attach to running android on emulator",
             "type": "cordova",
             "request": "attach",
             "platform": "android",
             "target": "emulator",
             "port": 9222,
-            "sourceMaps": true,
-            "cwd": "${workspaceFolder}"
-          },
-          {
-            "name": "Attach to running iOS on simulator",
-            "type": "cordova",
-            "request": "attach",
-            "platform": "ios",
-            "target": "emulator",
-            "port": 9220,
             "sourceMaps": true,
             "cwd": "${workspaceFolder}"
           },
@@ -229,27 +208,52 @@
         ],
         "configurationSnippets": [
           {
-            "label": "Cordova: Run",
-            "description": "Run and debug Cordova app on device/emulator",
+            "label": "Cordova: Run on Android",
+            "description": "Run and debug Cordova app on Android device/emulator",
             "body": {
-              "name": "${3:Run ${1:android|ios} on ${2:device|emulator}}",
+              "name": "${2:Run android on ${1:device|emulator}}",
               "type": "cordova",
               "request": "launch",
-              "platform": "${1:android|ios}",
-              "target": "${2:device|emulator}",
+              "platform": "android",
+              "target": "${1:device|emulator}",
               "sourceMaps": true,
               "cwd": "^\"\\${workspaceFolder}\""
             }
           },
           {
-            "label": "Cordova: Attach",
-            "description": "Attach to running Cordova app on device/emulator",
+            "label": "Cordova: Run on iOS",
+            "description": "Run and debug Cordova app on iOS device",
             "body": {
-              "name": "${3:Attach to ${1:android|ios} on ${2:device|emulator}}",
+              "name": "Run iOS on device",
+              "type": "cordova",
+              "request": "launch",
+              "platform": "ios",
+              "target": "$device",
+              "sourceMaps": true,
+              "cwd": "^\"\\${workspaceFolder}\""
+            }
+          },
+          {
+            "label": "Cordova: Attach to Android",
+            "description": "Attach to running Cordova app on Android device/emulator",
+            "body": {
+              "name": "${2:Attach to android on ${1:device|emulator}}",
               "type": "cordova",
               "request": "attach",
-              "platform": "${1:android|ios}",
-              "target": "${2:device|emulator}",
+              "platform": "android",
+              "target": "${1:device|emulator}",
+              "cwd": "^\"\\${workspaceFolder}\"",
+              "sourceMaps": true
+            }
+          },{
+            "label": "Cordova: Attach to iOS",
+            "description": "Attach to running Cordova app on iOS device",
+            "body": {
+              "name": "Attach to ios on device",
+              "type": "cordova",
+              "request": "attach",
+              "platform": "ios",
+              "target": "device",
               "cwd": "^\"\\${workspaceFolder}\"",
               "sourceMaps": true
             }

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -220,7 +220,14 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
         return new Promise<void>((resolve, reject) => this.initializeTelemetry(launchArgs.cwd)
             .then(() => TelemetryHelper.generate("launch", (generator) => {
                 launchArgs.port = launchArgs.port || 9222;
-                launchArgs.target = launchArgs.target || (launchArgs.platform === "browser" ? "chrome" : "emulator");
+                if (!launchArgs.target) {
+                    if(launchArgs.platform === "browser"){
+                        launchArgs.target = "chrome";
+                    } else {
+                        launchArgs.target = "emulator";
+                    }
+                    this.outputLogger(`Parameter target is not set - ${launchArgs.target} will be used`);
+                }
                 generator.add("target", CordovaDebugAdapter.getTargetType(launchArgs.target), false);
                 launchArgs.cwd = CordovaProjectHelper.getCordovaProjectRoot(launchArgs.cwd);
 


### PR DESCRIPTION
This PR disables debugging on iOS simulators due to Apple has broken current approach we used and IWDP can't connect to application webview anymore.
https://github.com/google/ios-webkit-debug-proxy/issues/250

What changes this PR introduces:
* Remove related default debug configurations (Run iOS on simulator, Attach to running iOS on simulator)
* Update configuration snippets: remove any mention of emulator for iOS
* Debugger checks if target value contains no "emulator" or emulator device ids and if it does shows an error.

@dhanvikapila does this workflow work for us? Could you please, also, take a look at Readme changes and this error string and give us suggestions for changing them if needed: https://github.com/Microsoft/vscode-cordova/compare/master...ruslan-bikkinin:disable-run-on-ios-simulators?expand=1#diff-b0f7f8daa1da800e681fd92bc82fd49eR742

