### PR TITLE
Fix regex issue for Node 8.9.3

### DIFF
--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -747,12 +747,10 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
         }
         return cordovaRunCommand(cordovaCommand, ["emulate", "ios", "--list"], env, workingDirectory).then((output) => {
             // Get list of emulators as raw strings
-            let match = output[0].match(/Available iOS Simulators:(.*)/gs);
-            if (!match) {
-                return false;
-            }
+            output[0] = output[0].replace(/Available iOS Simulators:/, "");
+
             // Clean up each string to get real value
-            const emulators = match[0].split("\n").map((value) => {
+            const emulators = output[0].split("\n").map((value) => {
                 let match = value.match(/(.*)(?=,)/gm);
                 if (!match) {
                     return null;


### PR DESCRIPTION
Flag /s isn't supported in Node v8.9.3 that leads to extension to crash on VS Code 1.30.