### PR TITLE
Add error notifications and bump vscode-chrome-debug-core dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ If you don’t wish to send usage data to Microsoft, please follow the instructi
 
 Due to recent changes in macOS we cannot connect to simulators to enable debugging of Cordova apps. We hope to re-introduce this functionality as soon as macOS provides a mechanism that allows the extension to connect to apps running in simulator. You can read more about the issue [here](https://github.com/google/ios-webkit-debug-proxy/issues/250).
 
+### Error `'Debugger' domain was not foundError processing "<attach/launch>": 'Debugger' domain was not found: [object Object]`
+
+Due to recent changes in iOS we cannot connect to Ionic and Cordova applications which are using WKWebView for content rendering. This caused by changes in Webkit protocol in iOS version above 12.2. As soon as the [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy) version with the corresponding compatibility fix will be released, this issue should be resolved.
+You can read more about the issue [here](https://github.com/microsoft/vscode-cordova/issues/564).
+
 ### Error `'Cannot connect to runtime process, timeout after {0} ms - (reason: {1}).', '{_timeout}', '{_error}'` occured while running debug scenarios
 
 Try to increase attach timeout by adding `attachTimeout` configuration parameter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6956,9 +6956,9 @@
       }
     },
     "vscode-chrome-debug-core": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.8.3.tgz",
-      "integrity": "sha512-wX1C9fY43Z9Ez7fqOerIG0bC5aaUEyipgima/JnPro+rZkhbcFti78wGHJK1cSZrTpzlncWXldJKPMYj4eoT7Q==",
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/vscode-chrome-debug-core/-/vscode-chrome-debug-core-6.8.6.tgz",
+      "integrity": "sha512-hgk5xw38D+q0tpS7P47ecNXCLvUt/+QyLzWnWXnYza+4Qfjd7XHrPXMw3BeQZ3g5PhOsvU/EoOqol7tU30TCTQ==",
       "requires": {
         "@types/source-map": "^0.1.27",
         "color": "^3.0.0",
@@ -7019,9 +7019,9 @@
       }
     },
     "vscode-uri": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.0.3.tgz",
-      "integrity": "sha512-4D3DI3F4uRy09WNtDGD93H9q034OHImxiIcSq664Hq1Y1AScehlP3qqZyTkX/RWxeu0MRMHGkrxYqm2qlDF/aw=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.1.tgz",
+      "integrity": "sha512-eY9jmGoEnVf8VE8xr5znSah7Qt1P/xsCdErz+g8HYZtJ7bZqKH5E3d+6oVNm1AC/c6IHUDokbmVXKOi4qPAC9A=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -583,7 +583,7 @@
     "q": "^1.4.1",
     "semver": "5.1.0",
     "socket.io-client": "^2.2.0",
-    "vscode-chrome-debug-core": "^6.8.3",
+    "vscode-chrome-debug-core": "^6.8.6",
     "vscode-debugadapter": "^1.37.1",
     "vscode-extension-telemetry": "0.0.5",
     "winreg": "0.0.13",

--- a/src/common/extensionMessaging.ts
+++ b/src/common/extensionMessaging.ts
@@ -62,7 +62,7 @@ export class ExtensionMessageSender {
         });
 
         socket.on("error", function (data: any) {
-            deferred.reject(new Error("An error occurred while handling message: " + ExtensionMessage[message] + data));
+            deferred.reject(new Error(`An error occurred while handling message: ${ExtensionMessage[message]} ${data}`));
         });
 
         socket.on("end", function () {

--- a/src/debugger/cordovaDebugAdapter.ts
+++ b/src/debugger/cordovaDebugAdapter.ts
@@ -163,11 +163,11 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
     }
 
     public static getRunArguments(projectRoot: string): Q.Promise<string[]> {
-        return new messaging.ExtensionMessageSender(projectRoot).sendMessage(messaging.ExtensionMessage.GET_RUN_ARGUMENTS, [projectRoot]);
+        return CordovaDebugAdapter.sendMessage(projectRoot, messaging.ExtensionMessage.GET_RUN_ARGUMENTS);
     }
 
     public static getCordovaExecutable(projectRoot: string): Q.Promise<string> {
-        return new messaging.ExtensionMessageSender(projectRoot).sendMessage(messaging.ExtensionMessage.GET_CORDOVA_EXECUTABLE, [projectRoot]);
+        return CordovaDebugAdapter.sendMessage(projectRoot, messaging.ExtensionMessage.GET_CORDOVA_EXECUTABLE);
     }
 
     private static retryAsync<T>(func: () => Q.Promise<T>, condition: (result: T) => boolean, maxRetries: number, iteration: number, delay: number, failure: string): Q.Promise<T> {
@@ -210,8 +210,8 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
         }
     }
 
-    private static sendLaunchMessage(projectRoot: string, func: (projectRoot: string) => Q.Promise<any>): Q.Promise<any> {
-        return func(projectRoot)
+    private static sendMessage(projectRoot: string, extensionMessage: messaging.ExtensionMessage): Q.Promise<any> {
+        return new messaging.ExtensionMessageSender(projectRoot).sendMessage(extensionMessage, [projectRoot])
             .catch(err => {
                 throw new Error(`${err.message} Please check whether 'cwd' parameter contains the path to the workspace root directory.`);
             });
@@ -271,8 +271,8 @@ export class CordovaDebugAdapter extends ChromeDebugAdapter {
 
                 return Q.all([
                     TelemetryHelper.determineProjectTypes(launchArgs.cwd),
-                    CordovaDebugAdapter.sendLaunchMessage(launchArgs.cwd, CordovaDebugAdapter.getRunArguments),
-                    CordovaDebugAdapter.sendLaunchMessage(launchArgs.cwd, CordovaDebugAdapter.getCordovaExecutable),
+                    CordovaDebugAdapter.getRunArguments(launchArgs.cwd),
+                    CordovaDebugAdapter.getCordovaExecutable(launchArgs.cwd),
                 ]).then(([projectType, runArguments, cordovaExecutable]) => {
                     launchArgs.cordovaExecutable = launchArgs.cordovaExecutable || cordovaExecutable;
                     launchArgs.env = CordovaProjectHelper.getEnvArgument(launchArgs);

--- a/src/utils/telemetryHelper.ts
+++ b/src/utils/telemetryHelper.ts
@@ -252,7 +252,12 @@ export class TelemetryHelper {
 
         // Write out new list of previousPlugins
         pluginFileJson.plugins = pluginsFileList;
-        fs.writeFileSync(pluginFilePath, JSON.stringify(pluginFileJson), "utf8");
+        try {
+            fs.writeFileSync(pluginFilePath, JSON.stringify(pluginFileJson), "utf8");
+        } catch (err) {
+            throw new Error(err.message + " It seems that 'cwd' parameter doesn't refer to the workspace root directory. " +
+                "Please make sure that 'cwd' contains the path to the workspace root directory.");
+        }
     }
 
     private static setTelemetryEventProperty(event: Telemetry.TelemetryEvent, propertyName: string, propertyValue: string, isPii: boolean): void {


### PR DESCRIPTION
https://github.com/microsoft/vscode-cordova/issues/591
* Added error notifications about usage of incorrect `cwd` parameter when trying to debug a project located in a subdirectory
* Bumped `vscode-chrome-debug-core` dependency to v6.8.6