### PR TITLE
Fix the order of closing debugging sessions

### DIFF
--- a/src/debugger/cordovaDebugSession.ts
+++ b/src/debugger/cordovaDebugSession.ts
@@ -394,7 +394,7 @@ export class CordovaDebugSession extends LoggingDebugSession {
             debugSession.configuration.cordovaDebugSessionId === this.cordovaSession.getSessionId()
             && debugSession.type === this.pwaSessionName
         ) {
-            vscode.commands.executeCommand(this.stopCommand, this.vsCodeDebugSession);
+            vscode.commands.executeCommand(this.stopCommand, undefined, { sessionId: this.vsCodeDebugSession.id });
         }
     }
 


### PR DESCRIPTION
Added transferring of process id while closing it

_Related to the issue:_ #706 
