### PR TITLE
Fix code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -181,7 +181,10 @@ export function killTree(processId: number): void {
         process.platform === "win32"
             ? "taskkill.exe"
             : path.join(findFileInFolderHierarchy(__dirname, "scripts"), "terminateProcess.sh");
-    const args = process.platform === "win32" ? ["/F", "/T", "/PID", processId.toString()] : [processId.toString()];
+    const args =
+        process.platform === "win32"
+            ? ["/F", "/T", "/PID", processId.toString()]
+            : [processId.toString()];
 
     try {
         child_process.execFileSync(cmd, args);

--- a/src/debugger/extension.ts
+++ b/src/debugger/extension.ts
@@ -179,11 +179,12 @@ export function cordovaStartCommand(
 export function killTree(processId: number): void {
     const cmd =
         process.platform === "win32"
-            ? "taskkill.exe /F /T /PID"
+            ? "taskkill.exe"
             : path.join(findFileInFolderHierarchy(__dirname, "scripts"), "terminateProcess.sh");
+    const args = process.platform === "win32" ? ["/F", "/T", "/PID", processId.toString()] : [processId.toString()];
 
     try {
-        child_process.execSync(`${cmd} ${processId}`);
+        child_process.execFileSync(cmd, args);
     } catch (err) {}
 }
 


### PR DESCRIPTION
Fixes [https://github.com/microsoft/vscode-cordova/security/code-scanning/1](https://github.com/microsoft/vscode-cordova/security/code-scanning/1)

To fix the problem, we should avoid constructing the shell command dynamically with unsanitized input. Instead, we can use the `child_process.execFileSync` method, which allows us to pass the command and its arguments separately, thereby avoiding shell interpretation of special characters.

Specifically, we need to:
1. Modify the `killTree` function to use `child_process.execFileSync` instead of `child_process.execSync`.
2. Pass the `processId` as an argument to the command rather than including it in the command string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
