### PR TITLE
Fix for code scanning alert no. 7: Shell command built from environment values

### DIFF
--- a/src/utils/cordovaCommandHelper.ts
+++ b/src/utils/cordovaCommandHelper.ts
@@ -105,7 +105,8 @@ export class CordovaCommandHelper {
                                     reject(err);
                                 });
                         } else {
-                            process = child_process.exec(commandToExecute, {
+                            const [cmd, ...args] = commandToExecute.split(" ");
+                            process = child_process.execFile(cmd, args, {
                                 cwd: projectRoot,
                                 env,
                             });
@@ -136,7 +137,7 @@ export class CordovaCommandHelper {
                             process.stdout.on("close", () => {
                                 // Workaround for dealing with plugman environment verification
                                 if (command === "requirements") {
-                                    process = child_process.exec("npm list -g plugman --depth=0", {
+                                    process = child_process.execFile("npm", ["list", "-g", "plugman", "--depth=0"], {
                                         cwd: projectRoot,
                                         env,
                                     });

--- a/src/utils/cordovaCommandHelper.ts
+++ b/src/utils/cordovaCommandHelper.ts
@@ -137,10 +137,14 @@ export class CordovaCommandHelper {
                             process.stdout.on("close", () => {
                                 // Workaround for dealing with plugman environment verification
                                 if (command === "requirements") {
-                                    process = child_process.execFile("npm", ["list", "-g", "plugman", "--depth=0"], {
-                                        cwd: projectRoot,
-                                        env,
-                                    });
+                                    process = child_process.execFile(
+                                        "npm",
+                                        ["list", "-g", "plugman", "--depth=0"],
+                                        {
+                                            cwd: projectRoot,
+                                            env,
+                                        },
+                                    );
 
                                     process.stdout.on("data", (e: string) => {
                                         const match = e.match(/\d+\.\d+\.\d+/);


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/vscode-cordova/security/code-scanning/7](https://github.com/microsoft/vscode-cordova/security/code-scanning/7)

To fix the problem, we should avoid constructing the command string dynamically and instead use the `child_process.execFile` method, which allows us to pass arguments separately from the command itself. This approach prevents the shell from interpreting special characters in the arguments.

1. Replace the use of `child_process.exec` with `child_process.execFile`.
2. Construct the command and its arguments separately.
3. Pass the command and arguments to `child_process.execFile`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
