### PR TITLE
Resolve security vulnerability by forcing serialize-javascript to 7.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11229,12 +11229,13 @@
 			"license": "MIT"
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+			"integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
 			"dev": true,
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -800,6 +800,7 @@
 		},
 		"cordova-simulate": {
 			"elliptic": "^6.6.1"
-		}
+		},
+		"serialize-javascript": "7.0.3"
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes a transitive security vulnerability by forcing `serialize-javascript`
to version **7.0.3**, which is the first patched release.

The current dependency graph pulls in `serialize-javascript@6.0.2` via:
- `mocha@11.0.1`
- `webpack -> terser-webpack-plugin@5.3.16`

Because both dependencies pin the range to `^6.0.2`, Dependabot is unable to resolve
a non-vulnerable version automatically.

---

## What changed

- Added an npm `overrides` entry in `package.json` to force:
  - `serialize-javascript@7.0.3`
- Reinstalled dependencies to update the resolved dependency tree

---

## Verification

- `npm ls serialize-javascript` confirms version **7.0.3** is installed and deduped
- `npm test` passes locally (exit code 0)

---

## Notes

- This change does not modify upstream dependency versions
- The override is scoped to address a security issue where the dependency graph
  otherwise cannot be resolved safely
- No functional or runtime behavior changes are expected
