### PR TITLE
fix: upgrade uuid to ^14.0.0 to address security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"plist": "^3.0.5",
 				"semver": "^6.3.1",
 				"socket.io-client": "2.4.0",
-				"uuid": "^9.0.0",
+				"uuid": "^14.0.0",
 				"vscode-cdp-proxy": "^0.2.0",
 				"vscode-extension-telemetry": "0.4.5",
 				"vscode-nls": "^4.1.2",
@@ -36,7 +36,7 @@
 				"@types/semver": "^5.5.0",
 				"@types/sinon": "^10.0.12",
 				"@types/socket.io-client": "^1.4.36",
-				"@types/uuid": "^9.0.0",
+				"@types/uuid": "^11.0.0",
 				"@types/vscode": "1.40.0",
 				"@typescript-eslint/eslint-plugin": "^6.15.0",
 				"@typescript-eslint/parser": "^6.15.0",
@@ -1271,10 +1271,15 @@
 			"dev": true
 		},
 		"node_modules/@types/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
-			"dev": true
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
+			"integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
+			"deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"uuid": "*"
+			}
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.40.0",
@@ -9132,15 +9137,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/mochawesome/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/module-deps": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
@@ -12789,11 +12785,16 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-			"integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+			"integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/v8-compile-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2197,15 +2197,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.5",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
-			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -2229,30 +2230,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.3",
@@ -2630,13 +2607,6 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
-		"node_modules/asn1.js/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/assert": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.1.tgz",
@@ -2778,9 +2748,13 @@
 			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/bare-events": {
 			"version": "2.4.2",
@@ -2910,9 +2884,9 @@
 			"integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
 		},
 		"node_modules/bn.js": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-			"integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+			"integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2958,13 +2932,15 @@
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/braces": {
@@ -3738,11 +3714,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
 		"node_modules/concat-stream": {
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -3980,13 +3951,6 @@
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.5.3"
 			}
-		},
-		"node_modules/create-ecdh/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
@@ -4430,10 +4394,11 @@
 			"dev": true
 		},
 		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
 			"dev": true,
+			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -4449,13 +4414,6 @@
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
 			}
-		},
-		"node_modules/diffie-hellman/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
@@ -4650,13 +4608,6 @@
 				"minimalistic-assert": "^1.0.1",
 				"minimalistic-crypto-utils": "^1.0.1"
 			}
-		},
-		"node_modules/elliptic/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/elliptic/node_modules/inherits": {
 			"version": "2.0.4",
@@ -5947,12 +5898,6 @@
 				"node": ">=8.6.0"
 			}
 		},
-		"node_modules/fast-json-stable-stringify": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
-		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -6178,10 +6123,11 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
-			"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
-			"dev": true
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/flush-write-stream": {
 			"version": "1.1.1",
@@ -6679,29 +6625,6 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/glob/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
-		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^4.0.2"
-			},
-			"engines": {
-				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
@@ -8236,10 +8159,11 @@
 			"dev": true
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -8797,13 +8721,6 @@
 				"miller-rabin": "bin/miller-rabin"
 			}
 		},
-		"node_modules/miller-rabin/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/mime": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -8873,15 +8790,15 @@
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
 			"license": "ISC",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=10"
 			}
 		},
 		"node_modules/minimist": {
@@ -9061,15 +8978,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
-			}
-		},
 		"node_modules/mocha/node_modules/debug": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -9085,15 +8993,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/mocha/node_modules/diff": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/mocha/node_modules/escape-string-regexp": {
@@ -9118,19 +9017,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/mocha/node_modules/minimatch": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/mocha/node_modules/ms": {
@@ -9232,15 +9118,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/mochawesome/node_modules/diff": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/mochawesome/node_modules/strip-ansi": {
@@ -10198,10 +10075,11 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -10411,13 +10289,6 @@
 				"randombytes": "^2.0.1",
 				"safe-buffer": "^5.1.2"
 			}
-		},
-		"node_modules/public-encrypt/node_modules/bn.js": {
-			"version": "4.12.2",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-			"integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/pump": {
 			"version": "3.0.0",
@@ -11017,23 +10888,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/schema-utils/node_modules/ajv-keywords": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
@@ -11046,13 +10900,6 @@
 			"peerDependencies": {
 				"ajv": "^8.8.2"
 			}
-		},
-		"node_modules/schema-utils/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/semver": {
 			"version": "6.3.1",
@@ -11666,12 +11513,13 @@
 			}
 		},
 		"node_modules/socket.io-parser": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.3.tgz",
-			"integrity": "sha512-1rE4dZN3kCI/E5wixd393hmbqa78vVpkKmnEJhLeWoS/C5hbFYAbcSfnWoaVH43u9ToUVtzKjguxEZq+1XZfCQ==",
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.4.tgz",
+			"integrity": "sha512-9JWZRGFA1aFK5W9yPrHoaZBOuaPE4NO7VZr96uVAsP8zkAYZkzrKeQhNPKkiPJq3qQK5q9c5xKcMysE5PUnPbw==",
+			"license": "MIT",
 			"dependencies": {
 				"component-emitter": "1.2.1",
-				"debug": "~4.3.1",
+				"debug": "~4.1.0",
 				"isarray": "2.0.1"
 			},
 			"engines": {
@@ -11684,25 +11532,20 @@
 			"integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA=="
 		},
 		"node_modules/socket.io-parser/node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
+				"ms": "^2.1.1"
 			}
 		},
 		"node_modules/socket.io-parser/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
 		},
 		"node_modules/socket.io/node_modules/debug": {
 			"version": "4.3.4",
@@ -12190,22 +12033,6 @@
 				"node": ">=10.0.0"
 			}
 		},
-		"node_modules/table/node_modules/ajv": {
-			"version": "8.6.3",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-			"integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
-			"dev": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/table/node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -12214,12 +12041,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/table/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true
 		},
 		"node_modules/table/node_modules/strip-ansi": {
 			"version": "6.0.1",
@@ -12909,24 +12730,6 @@
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
-			}
-		},
-		"node_modules/uri-js": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-			"dev": true,
-			"dependencies": {
-				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/uri-js/node_modules/punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/urix": {

--- a/package.json
+++ b/package.json
@@ -801,6 +801,16 @@
 		"cordova-simulate": {
 			"elliptic": "^6.6.1"
 		},
-		"serialize-javascript": "^7.0.3"
+		"serialize-javascript": "^7.0.3",
+		"brace-expansion": "^5.0.5",
+		"picomatch": "^2.3.2",
+		"flatted": "^3.4.2",
+		"socket.io-parser": "^3.4.4",
+		"minimatch": "^5.1.8",
+		"bn.js": "^5.2.3",
+		"ajv": "^8.18.0",
+		"qs": "^6.14.2",
+		"@isaacs/brace-expansion": "^5.0.1",
+		"diff": "^5.2.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -728,7 +728,7 @@
 		"plist": "^3.0.5",
 		"semver": "^6.3.1",
 		"socket.io-client": "2.4.0",
-		"uuid": "^9.0.0",
+		"uuid": "^14.0.0",
 		"vscode-cdp-proxy": "^0.2.0",
 		"vscode-extension-telemetry": "0.4.5",
 		"vscode-nls": "^4.1.2",
@@ -744,7 +744,7 @@
 		"@types/semver": "^5.5.0",
 		"@types/sinon": "^10.0.12",
 		"@types/socket.io-client": "^1.4.36",
-		"@types/uuid": "^9.0.0",
+		"@types/uuid": "^11.0.0",
 		"@types/vscode": "1.40.0",
 		"@typescript-eslint/eslint-plugin": "^6.15.0",
 		"@typescript-eslint/parser": "^6.15.0",
@@ -791,6 +791,7 @@
 		"ms-vscode.js-debug"
 	],
 	"overrides": {
+		"uuid": "^14.0.0",
 		"glob": ">=10.5.0",
 		"glob-stream": {
 			"glob": "^7.2.0"


### PR DESCRIPTION
## Résumé
- Upgrade `uuid` to `^14.0.0` to fix Dependabot alert #134 (missing buffer bounds check in v3/v5/v6)
- Update overrides to address additional security vulnerabilities

## Test Plan
- [ ] `npm install` completes without uuid-related audit issues
- [ ] Dependabot alert #134 closes after merge

Closes #1133