### PR TITLE
Fix security vulnerability: bump fast-uri from 3.1.0 to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6029,9 +6029,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -808,6 +808,7 @@
 		"vinyl-fs": {
 			"glob": "^7.2.0"
 		},
-		"serialize-javascript": ">=7.0.5"
+		"serialize-javascript": ">=7.0.5",
+		"fast-uri": ">=3.1.2"
 	}
 }


### PR DESCRIPTION
## Résumé

Bumps `fast-uri` from `3.1.0` to `3.1.2` via `overrides` to address two high-severity vulnerabilities:

- [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) (CVE-2026-6321): Path traversal via percent-encoded dot segments
- [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) (CVE-2026-6322): Host confusion via percent-encoded authority delimiters

Closes #1140