### PR TITLE
Fix security vulnerability: bump uuid override to 11.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1386,10 +1386,11 @@
 			"dev": true
 		},
 		"node_modules/@types/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
-			"dev": true
+			"version": "9.0.8",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+			"integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.40.0",
@@ -2035,118 +2036,6 @@
 				"@vscode/vsce-sign-win32-arm64": "2.0.6",
 				"@vscode/vsce-sign-win32-x64": "2.0.6"
 			}
-		},
-		"node_modules/@vscode/vsce-sign-alpine-arm64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
-			"integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"alpine"
-			]
-		},
-		"node_modules/@vscode/vsce-sign-alpine-x64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
-			"integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"alpine"
-			]
-		},
-		"node_modules/@vscode/vsce-sign-darwin-arm64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
-			"integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@vscode/vsce-sign-darwin-x64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
-			"integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@vscode/vsce-sign-linux-arm": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
-			"integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@vscode/vsce-sign-linux-arm64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
-			"integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@vscode/vsce-sign-linux-x64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
-			"integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@vscode/vsce-sign-win32-arm64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
-			"integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "SEE LICENSE IN LICENSE.txt",
-			"optional": true,
-			"os": [
-				"win32"
-			]
 		},
 		"node_modules/@vscode/vsce-sign-win32-x64": {
 			"version": "2.0.6",
@@ -3334,6 +3223,16 @@
 				"npm": "1.2.8000 || >= 1.4.16"
 			}
 		},
+		"node_modules/body-parser/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -4389,20 +4288,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"readable-stream": "3"
-			}
-		},
-		"node_modules/cordova-simulate/node_modules/uuid": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/core-js-compat": {
@@ -6378,6 +6263,16 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/express/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
 		"node_modules/express/node_modules/encodeurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -6580,6 +6475,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/finalhandler/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
 			}
 		},
 		"node_modules/finalhandler/node_modules/encodeurl": {
@@ -6897,21 +6802,6 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"license": "ISC"
-		},
-		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
 		},
 		"node_modules/fsu": {
 			"version": "1.1.1",
@@ -10042,15 +9932,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/mochawesome/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/module-deps": {
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
@@ -12195,6 +12076,16 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/send-transform/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
 		"node_modules/send-transform/node_modules/depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -12265,6 +12156,23 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/send/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/send/node_modules/debug/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/send/node_modules/encodeurl": {
 			"version": "2.0.0",
@@ -12738,6 +12646,31 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
 			"integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA=="
+		},
+		"node_modules/socket.io/node_modules/debug": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+			"integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/socket.io/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/socket.io/node_modules/socket.io-client": {
 			"version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -808,6 +808,12 @@
 		"vinyl-fs": {
 			"glob": "^7.2.0"
 		},
-		"serialize-javascript": ">=7.0.5"
+		"serialize-javascript": ">=7.0.5",
+		"cordova-simulate": {
+			"uuid": ">=11.1.1"
+		},
+		"mochawesome": {
+			"uuid": ">=11.1.1"
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Bumps `uuid` transitive dependencies to `>=11.1.1` via nested `overrides` in `package.json` to address CVE-2026-41907 (CVSS 7.5). `cordova-simulate` and `mochawesome` were pulling in `uuid@9.0.1` and `uuid@8.3.2` respectively, which are affected by a missing buffer bounds check in v3/v5/v6 when `buf` is provided.

## Proposed Changes
- Add nested overrides for `cordova-simulate.uuid` and `mochawesome.uuid` set to `>=11.1.1` in `package.json`
- Regenerate `package-lock.json` — all uuid instances now resolve to `14.0.0`

## Test Plan
- Verify `npm ls uuid` shows all instances at `>=11.1.1` (currently `14.0.0` deduped)
- Run existing tests to confirm no regressions

Closes #1159