### PR TITLE
Fix Japanese mistranslation of the "Run" command (走る -> 実行)

### DIFF
--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -4,7 +4,7 @@
 	"cordova.workspaceTrust.description": "このワークスペースでコードをデバッグし、コマンド パレット コマンドを実行するには信頼が必要です。",
 	"cordova.build": "Cordova: ビルド",
 	"cordova.restart": "Cordova のデバッグを再開する",
-	"cordova.run": "Cordova: 走る",
+	"cordova.run": "Cordova: 実行",
 	"cordova.prepare": "Cordova: 準備する",
 	"cordova.requirements": "Cordova: 要件",
 	"cordova.simulate.android": "Cordova: ブラウザーで Android をシミュレートする",


### PR DESCRIPTION
The Japanese label for the `cordova.run` command reads "Cordova: 走る". 走る means "run" in the sense of running on foot, which does not fit a command that runs (launches/executes) the app.

The adjacent `cordova.ionic.run` key already uses the correct sense, "Ionic: 実行" (実行 = execute/run a program), and the other run-related keys in this file (`cordova.snippets.*RunOn*`, `runArguments`) also use 実行. The English source for both commands is "Run", and the zh-cn file uses 运行 (execute) for `cordova.run`.

This changes only that one string so it matches its sibling:

`"cordova.run": "Cordova: 走る"` -> `"cordova.run": "Cordova: 実行"`

There is no code change, so no test accompanies it (this is a localized-string fix).
