### PR TITLE
Fix security vulnerability: bump brace-expansion override to v5.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3331,8 +3331,8 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "git+ssh://git@github.com/juliangruber/brace-expansion.git#96a63c0011c0288846ad41773c73e3fbd0906b59",
+			"version": "5.0.9",
+			"resolved": "git+ssh://git@github.com/juliangruber/brace-expansion.git#fbcf8ec75b88c79374b4aac06559b1a5288a1223",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -810,11 +810,11 @@
 			"glob": "^7.2.0"
 		},
 		"minimatch": {
-			"brace-expansion": "github:juliangruber/brace-expansion#v5.0.8"
+			"brace-expansion": "github:juliangruber/brace-expansion#v5.0.9"
 		},
-		"brace-expansion": "github:juliangruber/brace-expansion#v5.0.8",
+		"brace-expansion": "github:juliangruber/brace-expansion#v5.0.9",
 		"@vscode/vsce": {
-			"brace-expansion": "github:juliangruber/brace-expansion#v5.0.8"
+			"brace-expansion": "github:juliangruber/brace-expansion#v5.0.9"
 		},
 		"js-yaml": "github:nodeca/js-yaml#5.2.2",
 		"serialize-javascript": ">=7.0.5",


### PR DESCRIPTION
## Summary

Bump the `brace-expansion` npm override from `github:juliangruber/brace-expansion#v5.0.8` to `github:juliangruber/brace-expansion#v5.0.9` to address CVE-2026-69152 (GHSA-rgw5-rvv9-x895, CVSS 7.5 High).

The three affected override entries (`overrides.brace-expansion`, `overrides.minimatch.brace-expansion`, `overrides.@vscode/vsce.brace-expansion`) are all updated. `brace-expansion@5.0.9` is not yet published to npm, so the GitHub ref pattern is kept consistent with the existing approach.

Closes #1188

## Test Plan

- CI passes.
- `npm ls brace-expansion` shows no version in the vulnerable range `>= 4.0.0, < 5.0.9`.